### PR TITLE
feat: make SuperwallDelegate a concrete class with empty member implementations

### DIFF
--- a/src/compat/lib/SuperwallDelegate.ts
+++ b/src/compat/lib/SuperwallDelegate.ts
@@ -1,25 +1,30 @@
-import type { PaywallInfo } from "./PaywallInfo"
-import type { RedemptionResult } from "./RedemptionResults"
-import type { SubscriptionStatus } from "./SubscriptionStatus"
-import type { SuperwallEventInfo } from "./SuperwallEventInfo"
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// @ts-nocheck TS6133: Unused variable
+import { PaywallInfo } from "./PaywallInfo";
+import type { RedemptionResult } from "./RedemptionResults";
+import { SubscriptionStatus } from "./SubscriptionStatus";
+import { SuperwallEventInfo } from "./SuperwallEventInfo";
 
-export abstract class SuperwallDelegate {
-  abstract subscriptionStatusDidChange(from: SubscriptionStatus, to: SubscriptionStatus): void
-  abstract willRedeemLink(): void
-  abstract didRedeemLink(result: RedemptionResult): void
-  abstract handleSuperwallEvent(eventInfo: SuperwallEventInfo): void
-  abstract handleCustomPaywallAction(name: string): void
-  abstract willDismissPaywall(paywallInfo: PaywallInfo): void
-  abstract willPresentPaywall(paywallInfo: PaywallInfo): void
-  abstract didDismissPaywall(paywallInfo: PaywallInfo): void
-  abstract didPresentPaywall(paywallInfo: PaywallInfo): void
-  abstract paywallWillOpenURL(url: URL): void
-  abstract paywallWillOpenDeepLink(url: URL): void
-  abstract handleLog(
+export class SuperwallDelegate {
+  subscriptionStatusDidChange(
+    from: SubscriptionStatus,
+    to: SubscriptionStatus,
+  ): void {}
+  willRedeemLink(): void {}
+  didRedeemLink(result: RedemptionResult): void {}
+  handleSuperwallEvent(eventInfo: SuperwallEventInfo): void {}
+  handleCustomPaywallAction(name: string): void {}
+  willDismissPaywall(paywallInfo: PaywallInfo): void {}
+  willPresentPaywall(paywallInfo: PaywallInfo): void {}
+  didDismissPaywall(paywallInfo: PaywallInfo): void {}
+  didPresentPaywall(paywallInfo: PaywallInfo): void {}
+  paywallWillOpenURL(url: URL): void {}
+  paywallWillOpenDeepLink(url: URL): void {}
+  handleLog(
     level: string,
     scope: string,
     message?: string,
     info?: Record<string, any> | null,
     error?: string | null,
-  ): void
+  ): void {}
 }


### PR DESCRIPTION
Following this comment: https://github.com/superwall/react-native-superwall/pull/93#issuecomment-2956148371

## Changes in this pull request

- When implementing a `SuperwallDelegate` we face this error if we don't implement all the members 
```
Non-abstract class 'MySuperwallDelegate' is missing implementations for the following members of 'SuperwallDelegate': 'subscriptionStatusDidChange', 'willRedeemLink', 'didRedeemLink', 'handleSuperwallEvent' and 6 more.ts(2655)
⌘+click to open in new tab
⚠ Error (TS2655) | 

Non-abstract class 
 is missing implementations for the following members of SuperwallDelegate : subscriptionStatusDidChange , willRedeemLink , didRedeemLink , handleSuperwallEvent and 6 more.
class MySuperwallDelegate
```

- Most examples in [this doc](https://superwall.com/docs/using-superwall-delegate) generate TS errors, this PR would fix it by adding an empty function for each method.

