### PR TITLE
Fix coroutines version mismatch on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,5 +46,8 @@ dependencies {
   implementation "com.superwall.sdk:superwall-android:2.1.2"
   implementation 'com.android.billingclient:billing:6.1.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.2'
+  // Ensure compatibility with Superwall which targets kotlinx-coroutines 1.9
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0'
 }
 


### PR DESCRIPTION
## Summary
- depend on kotlinx-coroutines 1.9 to align with Superwall SDK

## Testing
- `bash run_tests.sh android` *(fails: PluginError: Failed to resolve plugin for module "expo-router" relative to ui_test_app)*

------
https://chatgpt.com/codex/tasks/task_e_68573545e0488326a7a46dbe26ea4b0c