### PR TITLE
Typed SuperwallOptions + manualPurchaseManagment fix

### DIFF
--- a/.changeset/itchy-ducks-brush.md
+++ b/.changeset/itchy-ducks-brush.md
@@ -1,0 +1,5 @@
+---
+"expo-superwall": patch
+---
+
+Add typed SuperwallOptions and fix mispelled option name

--- a/src/SuperwallOptions.ts
+++ b/src/SuperwallOptions.ts
@@ -1,66 +1,52 @@
 /**
- * @category Enums
+ * @category Types
  * @since 0.0.15
  * Defines the log levels for the SDK.
  */
-export enum LogLevel {
-  Debug = "debug",
-  Info = "info",
-  Warn = "warn",
-  Error = "error",
-  None = "none",
-}
+export type LogLevel = "debug" | "info" | "warn" | "error" | "none"
 
 /**
- * @category Enums
+ * @category Types
  * @since 0.0.15
  * Defines the scopes for logging within the SDK.
  */
-export enum LogScope {
-  LocalizationManager = "localizationManager",
-  BounceButton = "bounceButton",
-  CoreData = "coreData",
-  ConfigManager = "configManager",
-  IdentityManager = "identityManager",
-  DebugManager = "debugManager",
-  DebugViewController = "debugViewController",
-  LocalizationViewController = "localizationViewController",
-  GameControllerManager = "gameControllerManager",
-  Device = "device",
-  Network = "network",
-  PaywallEvents = "paywallEvents",
-  ProductsManager = "productsManager",
-  StoreKitManager = "storeKitManager",
-  Placements = "placements",
-  Receipts = "receipts",
-  SuperwallCore = "superwallCore",
-  PaywallPresentation = "paywallPresentation",
-  PaywallTransactions = "paywallTransactions",
-  PaywallViewController = "paywallViewController",
-  Cache = "cache",
-  All = "all",
-}
+export type LogScope = 
+  | "localizationManager"
+  | "bounceButton"
+  | "coreData"
+  | "configManager"
+  | "identityManager"
+  | "debugManager"
+  | "debugViewController"
+  | "localizationViewController"
+  | "gameControllerManager"
+  | "device"
+  | "network"
+  | "paywallEvents"
+  | "productsManager"
+  | "storeKitManager"
+  | "placements"
+  | "receipts"
+  | "superwallCore"
+  | "paywallPresentation"
+  | "paywallTransactions"
+  | "paywallViewController"
+  | "cache"
+  | "all"
 
 /**
- * @category Enums
+ * @category Types
  * @since 0.0.15
  * Defines the network environment for Superwall.
  */
-export enum NetworkEnvironment {
-  Release = "release",
-  ReleaseCandidate = "releaseCandidate",
-  Developer = "developer",
-}
+export type NetworkEnvironment = "release" | "releaseCandidate" | "developer"
 
 /**
- * @category Enums
+ * @category Types
  * @since 0.0.15
  * Defines the different types of views that can appear behind Apple's payment sheet during a transaction.
  */
-export enum TransactionBackgroundView {
-  spinner = "spinner",
-  none = "none",
-}
+export type TransactionBackgroundView = "spinner" | "none"
 
 /**
  * @category Models
@@ -132,14 +118,14 @@ export const DefaultSuperwallOptions: SuperwallOptions = {
     shouldShowPurchaseFailureAlert: true,
     shouldPreload: false,
     automaticallyDismiss: true,
-    transactionBackgroundView: TransactionBackgroundView.spinner,
+    transactionBackgroundView: "spinner",
   },
-  networkEnvironment: NetworkEnvironment.Release,
+  networkEnvironment: "release",
   isExternalDataCollectionEnabled: true,
   isGameControllerEnabled: false,
   logging: {
-    level: LogLevel.Info,
-    scopes: [LogScope.All],
+    level: "info",
+    scopes: ["all"],
   },
   collectAdServicesAttribution: false,
   passIdentifiersToPlayStore: false,

--- a/src/SuperwallOptions.ts
+++ b/src/SuperwallOptions.ts
@@ -1,0 +1,148 @@
+/**
+ * @category Enums
+ * @since 0.0.15
+ * Defines the log levels for the SDK.
+ */
+export enum LogLevel {
+  Debug = "debug",
+  Info = "info",
+  Warn = "warn",
+  Error = "error",
+  None = "none",
+}
+
+/**
+ * @category Enums
+ * @since 0.0.15
+ * Defines the scopes for logging within the SDK.
+ */
+export enum LogScope {
+  LocalizationManager = "localizationManager",
+  BounceButton = "bounceButton",
+  CoreData = "coreData",
+  ConfigManager = "configManager",
+  IdentityManager = "identityManager",
+  DebugManager = "debugManager",
+  DebugViewController = "debugViewController",
+  LocalizationViewController = "localizationViewController",
+  GameControllerManager = "gameControllerManager",
+  Device = "device",
+  Network = "network",
+  PaywallEvents = "paywallEvents",
+  ProductsManager = "productsManager",
+  StoreKitManager = "storeKitManager",
+  Placements = "placements",
+  Receipts = "receipts",
+  SuperwallCore = "superwallCore",
+  PaywallPresentation = "paywallPresentation",
+  PaywallTransactions = "paywallTransactions",
+  PaywallViewController = "paywallViewController",
+  Cache = "cache",
+  All = "all",
+}
+
+/**
+ * @category Enums
+ * @since 0.0.15
+ * Defines the network environment for Superwall.
+ */
+export enum NetworkEnvironment {
+  Release = "release",
+  ReleaseCandidate = "releaseCandidate",
+  Developer = "developer",
+}
+
+/**
+ * @category Enums
+ * @since 0.0.15
+ * Defines the different types of views that can appear behind Apple's payment sheet during a transaction.
+ */
+export enum TransactionBackgroundView {
+  spinner = "spinner",
+  none = "none",
+}
+
+/**
+ * @category Models
+ * @since 0.0.15
+ * Defines the messaging of the alert presented to the user when restoring a transaction fails.
+ */
+export interface RestoreFailed {
+  title: string
+  message: string
+  closeButtonTitle: string
+}
+
+/**
+ * @category Models
+ * @since 0.0.15
+ * Options for configuring logging behavior.
+ */
+export interface LoggingOptions {
+  level: LogLevel
+  scopes: LogScope[]
+}
+
+/**
+ * @category Models
+ * @since 0.0.15
+ * Options for configuring the appearance and behavior of paywalls.
+ */
+export interface PaywallOptions {
+  isHapticFeedbackEnabled: boolean
+  restoreFailed: RestoreFailed
+  shouldShowPurchaseFailureAlert: boolean
+  shouldPreload: boolean
+  automaticallyDismiss: boolean
+  transactionBackgroundView: TransactionBackgroundView
+}
+
+/**
+ * @category Models
+ * @since 0.0.15
+ * Options for configuring the Superwall SDK.
+ */
+export interface SuperwallOptions {
+  paywalls: PaywallOptions
+  networkEnvironment: NetworkEnvironment
+  isExternalDataCollectionEnabled: boolean
+  localeIdentifier?: string
+  isGameControllerEnabled: boolean
+  logging: LoggingOptions
+  collectAdServicesAttribution: boolean
+  passIdentifiersToPlayStore: boolean
+  storeKitVersion?: "STOREKIT1" | "STOREKIT2"
+  enableExperimentalDeviceVariables: boolean
+  manualPurchaseManagement: boolean
+}
+
+/**
+ * @category Models
+ * @since 0.0.15
+ * Default options for the Superwall SDK.
+ */
+export const DefaultSuperwallOptions: SuperwallOptions = {
+  paywalls: {
+    isHapticFeedbackEnabled: true,
+    restoreFailed: {
+      title: "No Subscription Found",
+      message: "We couldn't find an active subscription for your account.",
+      closeButtonTitle: "Okay",
+    },
+    shouldShowPurchaseFailureAlert: true,
+    shouldPreload: false,
+    automaticallyDismiss: true,
+    transactionBackgroundView: TransactionBackgroundView.spinner,
+  },
+  networkEnvironment: NetworkEnvironment.Release,
+  isExternalDataCollectionEnabled: true,
+  isGameControllerEnabled: false,
+  logging: {
+    level: LogLevel.Info,
+    scopes: [LogScope.All],
+  },
+  collectAdServicesAttribution: false,
+  passIdentifiersToPlayStore: false,
+  enableExperimentalDeviceVariables: false,
+  manualPurchaseManagement: false,
+}

--- a/src/SuperwallProvider.tsx
+++ b/src/SuperwallProvider.tsx
@@ -3,6 +3,7 @@ import { type EmitterSubscription, Linking, Platform } from "react-native"
 import { useShallow } from "zustand/shallow"
 import { useCustomPurchaseController } from "./CustomPurchaseControllerProvider"
 import SuperwallExpoModule from "./SuperwallExpoModule"
+import type { SuperwallOptions } from "./SuperwallOptions"
 import { SuperwallContext, useSuperwallStore } from "./useSuperwall"
 
 interface SuperwallProviderProps {
@@ -12,7 +13,10 @@ interface SuperwallProviderProps {
     ios?: string
   }
   /** Optional configuration options passed to the native SDK */
-  options?: Record<string, any>
+  options?: Partial<SuperwallOptions> & {
+    /** @deprecated Use manualPurchaseManagement instead */
+    manualPurchaseManagment?: boolean
+  }
   /** App content to render once configured */
   children: ReactNode
 }
@@ -64,7 +68,7 @@ export function SuperwallProvider({
 
       configure(apiKey, {
         ...options,
-        manualPurchaseManagment: isUsingCustomPurchaseController,
+        manualPurchaseManagement: isUsingCustomPurchaseController,
       }).catch((err) => {
         console.error("Superwall configure failed", err)
       })


### PR DESCRIPTION
## Enhancements

- Adds typed `SuperwallOptions` to pass into provider or configure.
- Renames `manualPurchaseManagment` to `manualPurchaseManagement` while deprecating the old name