### PR TITLE
Add expo wiring for consume Android function

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-  implementation "com.superwall.sdk:superwall-android:2.6.1"
+  implementation "com.superwall.sdk:superwall-android:2.6.2"
   implementation 'com.android.billingclient:billing:8.0.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.2'
 }

--- a/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
@@ -402,5 +402,20 @@ class SuperwallExpoModule : Module() {
         Superwall.instance.logLevel = logLevel
       }
     }
+
+    AsyncFunction("consume") { purchaseToken, promise: Promise ->
+      ioScope.launch {
+        Superwall.instance.consume(purchaseToken)
+          .fold({ result ->
+            scope.launch {
+              promise.resolve(result)
+            }
+          }, { error ->
+            scope.launch {
+              promise.reject(CodedException(error))
+            }
+          })
+      }
+    }
   }
 }

--- a/src/SuperwallExpoModule.ts
+++ b/src/SuperwallExpoModule.ts
@@ -58,6 +58,8 @@ declare class SuperwallExpoModule extends NativeModule<SuperwallExpoModuleEvents
   preloadPaywalls(placementNames: string[]): void
   preloadAllPaywalls(): void
 
+  consume(purchaseToken: string): Promise<string>
+
   setLogLevel(level: string): void
 }
 

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -632,6 +632,18 @@ export default class Superwall {
   }
 
   /**
+   * Initiates a consumption of an In-App product.
+   *
+   * Use this function to consume an In-App product after processing it in your application.
+   *
+   * @param {string} purchaseToken - The token related to the purchase you wish to consume.
+   * @return {Promise<string>} Containing the consumed token, or an error.
+   */
+  async consume(purchaseToken: string): Promise<string> {
+    return await SuperwallExpoModule.consume(purchaseToken)
+  }
+
+  /**
    * Sets user attributes for use in paywalls and on the Superwall dashboard.
    *
    * If an attribute already exists, its value will be overwritten while other attributes remain unchanged.

--- a/src/useSuperwall.ts
+++ b/src/useSuperwall.ts
@@ -262,6 +262,9 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
     const attributes = await SuperwallExpoModule.getDeviceAttributes()
     return attributes
   },
+  consume: async (purchaseToken: string) => {
+    return await SuperwallExpoModule.consume(purchaseToken)
+  },
 
   /* -------------------- Listener helpers -------------------- */
   _initListeners: (): (() => void) => {


### PR DESCRIPTION
# Summary

After @ianrumac exposed `consume` functions in the base repo to allow users to directly consume an In App purchase using a token, the functionality was missing in Expo.

This PR aims to wire it appropriately, using the latest superwall-android SDK version (2.6.2) and defining an AsyncFunction that matches its signature/usage.

# Changes
- Update superwall-android SDK to 2.6.2
- Add `AsyncFunction("consume")` to `SuperwallExpoModule` for Android wiring
- Expose `consume` in `SuperwallExpoModule` for TS 
- Wire `consume` in `index.ts` (compat) and `useSuperwall.ts` (core)

# Test Plan

N/A for now, as this is a PoC/WIP -> looking for a way to test this thoroughly