### PR TITLE
fix(android): handle nullable properties in RedemptionResult JSON serialization

### DIFF
--- a/.changeset/fix-android-nullable-properties.md
+++ b/.changeset/fix-android-nullable-properties.md
@@ -1,0 +1,7 @@
+---
+"expo-superwall": patch
+---
+
+fix(android): handle nullable properties in RedemptionResult JSON serialization
+
+Fixed a Kotlin compilation error where nullable properties (`variantId`, `experimentId`, `productIdentifier`) were being assigned directly to a Map<String, Any>. Now using the null-safe let operator to conditionally add these properties only when they have values.

--- a/android/src/main/java/expo/modules/superwallexpo/json/RedemptionResult.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/json/RedemptionResult.kt
@@ -130,8 +130,8 @@ private fun RedemptionResult.PaywallInfo.toJson(): Map<String, Any> {
     }
     map["placementParams"] = placementParamsMap
 
-    map["variantId"] = this.variantId
-    map["experimentId"] = this.experimentId
-    map["productIdentifier"] = this.productIdentifier
+    this.variantId?.let { map["variantId"] = it }
+    this.experimentId?.let { map["experimentId"] = it }
+    this.productIdentifier?.let { map["productIdentifier"] = it }
     return map
 }


### PR DESCRIPTION
## Summary
- Fixed a Kotlin compilation error where nullable properties were being assigned directly to a Map<String, Any>
- Now using the null-safe let operator to conditionally add these properties only when they have values
- This resolves the Android build failure reported in #99

## Test plan
- [x] Applied the fix to the affected file
- [x] Verified similar nullable property handling patterns in other JSON serialization files
- [ ] Android build should now complete successfully without type mismatch errors

Fixes #99

🤖 Generated with [Claude Code](https://claude.ai/code)