### PR TITLE
feat: add missing SDK configuration options

### DIFF
--- a/.changeset/add-missing-sdk-options.md
+++ b/.changeset/add-missing-sdk-options.md
@@ -1,0 +1,14 @@
+---
+"expo-superwall": minor
+---
+
+Add missing SDK configuration options from native iOS and Android SDKs:
+
+- `shouldObservePurchases` (iOS & Android): Observe purchases made outside of Superwall
+- `shouldBypassAppTransactionCheck` (iOS only): Disables app transaction check on SDK launch
+- `maxConfigRetryCount` (iOS only): Number of retry attempts for config fetch (default: 6)
+- `useMockReviews` (Android only): Enable mock review functionality
+
+Also fixes `enableExperimentalDeviceVariables` not being passed to the Android native SDK.
+
+**Breaking change**: Removed deprecated `collectAdServicesAttribution` option (AdServices attribution is now collected automatically by the native iOS SDK).

--- a/android/src/main/java/expo/modules/superwallexpo/json/SuperwallOptions.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/json/SuperwallOptions.kt
@@ -12,7 +12,10 @@ fun superwallOptionsFromJson(json: Map<String, Any?>): SuperwallOptions {
   options.localeIdentifier = json["localeIdentifier"] as String?
   options.isExternalDataCollectionEnabled = (json["isExternalDataCollectionEnabled"] as Boolean?)?:true
   options.isGameControllerEnabled = (json["isGameControllerEnabled"] as Boolean?)?:false
-    options.passIdentifiersToPlayStore = (json["passIdentifiersToPlayStore"] as Boolean?)?:false
+  options.passIdentifiersToPlayStore = (json["passIdentifiersToPlayStore"] as Boolean?)?:false
+  options.enableExperimentalDeviceVariables = (json["enableExperimentalDeviceVariables"] as Boolean?)?:false
+  options.shouldObservePurchases = (json["shouldObservePurchases"] as Boolean?)?:false
+  options.useMockReviews = (json["useMockReviews"] as Boolean?)?:false
 
       val networkEnvironment = when (json["networkEnvironment"] as String?) {
         "release" -> SuperwallOptions.NetworkEnvironment.Release()

--- a/ios/Json/SuperwallOptions+Json.swift
+++ b/ios/Json/SuperwallOptions+Json.swift
@@ -19,6 +19,9 @@ extension SuperwallOptions {
     let storeKitVersion = dictionary["storeKitVersion"] as? String
     let enableExperimentalDeviceVariables =
       dictionary["enableExperimentalDeviceVariables"] as? Bool ?? false
+    let shouldObservePurchases = dictionary["shouldObservePurchases"] as? Bool ?? false
+    let shouldBypassAppTransactionCheck = dictionary["shouldBypassAppTransactionCheck"] as? Bool ?? false
+    let maxConfigRetryCount = dictionary["maxConfigRetryCount"] as? Int ?? 6
 
     let superwallOptions = SuperwallOptions()
     superwallOptions.paywalls = paywalls
@@ -31,6 +34,9 @@ extension SuperwallOptions {
       superwallOptions.storeKitVersion = storeKitVersion == "STOREKIT1" ? .storeKit1 : .storeKit2
     }
     superwallOptions.enableExperimentalDeviceVariables = enableExperimentalDeviceVariables
+    superwallOptions.shouldObservePurchases = shouldObservePurchases
+    superwallOptions.shouldBypassAppTransactionCheck = shouldBypassAppTransactionCheck
+    superwallOptions.maxConfigRetryCount = maxConfigRetryCount
 
     return superwallOptions
   }

--- a/src/SuperwallOptions.ts
+++ b/src/SuperwallOptions.ts
@@ -96,11 +96,32 @@ export interface SuperwallOptions {
   localeIdentifier?: string
   isGameControllerEnabled: boolean
   logging: LoggingOptions
-  collectAdServicesAttribution: boolean
   passIdentifiersToPlayStore: boolean
   storeKitVersion?: "STOREKIT1" | "STOREKIT2"
   enableExperimentalDeviceVariables: boolean
   manualPurchaseManagement: boolean
+  /**
+   * Observe purchases made outside of Superwall. When true, Superwall will observe
+   * StoreKit/Play Store transactions and report them. Defaults to false.
+   * @platform iOS and Android
+   */
+  shouldObservePurchases: boolean
+  /**
+   * Disables the app transaction check on SDK launch. Defaults to false.
+   * @platform iOS only
+   */
+  shouldBypassAppTransactionCheck: boolean
+  /**
+   * Number of times the SDK will attempt to get the Superwall configuration after
+   * a network failure before it times out. Defaults to 6.
+   * @platform iOS only
+   */
+  maxConfigRetryCount: number
+  /**
+   * Enable mock review functionality. Defaults to false.
+   * @platform Android only
+   */
+  useMockReviews: boolean
 }
 
 /**
@@ -117,11 +138,32 @@ export interface PartialSuperwallOptions {
   localeIdentifier?: string
   isGameControllerEnabled?: boolean
   logging?: Partial<LoggingOptions>
-  collectAdServicesAttribution?: boolean
   passIdentifiersToPlayStore?: boolean
   storeKitVersion?: "STOREKIT1" | "STOREKIT2"
   enableExperimentalDeviceVariables?: boolean
   manualPurchaseManagement?: boolean
+  /**
+   * Observe purchases made outside of Superwall. When true, Superwall will observe
+   * StoreKit/Play Store transactions and report them. Defaults to false.
+   * @platform iOS and Android
+   */
+  shouldObservePurchases?: boolean
+  /**
+   * Disables the app transaction check on SDK launch. Defaults to false.
+   * @platform iOS only
+   */
+  shouldBypassAppTransactionCheck?: boolean
+  /**
+   * Number of times the SDK will attempt to get the Superwall configuration after
+   * a network failure before it times out. Defaults to 6.
+   * @platform iOS only
+   */
+  maxConfigRetryCount?: number
+  /**
+   * Enable mock review functionality. Defaults to false.
+   * @platform Android only
+   */
+  useMockReviews?: boolean
 }
 
 /**
@@ -150,8 +192,11 @@ export const DefaultSuperwallOptions: SuperwallOptions = {
     level: "info",
     scopes: ["all"],
   },
-  collectAdServicesAttribution: false,
   passIdentifiersToPlayStore: false,
   enableExperimentalDeviceVariables: false,
   manualPurchaseManagement: false,
+  shouldObservePurchases: false,
+  shouldBypassAppTransactionCheck: false,
+  maxConfigRetryCount: 6,
+  useMockReviews: false,
 }

--- a/src/compat/lib/SuperwallOptions.ts
+++ b/src/compat/lib/SuperwallOptions.ts
@@ -53,10 +53,31 @@ export class SuperwallOptions {
   localeIdentifier?: string
   isGameControllerEnabled = false
   logging: LoggingOptions = new LoggingOptions()
-  collectAdServicesAttribution = false
   passIdentifiersToPlayStore = false
   storeKitVersion?: "STOREKIT1" | "STOREKIT2"
   enableExperimentalDeviceVariables = false
+  /**
+   * Observe purchases made outside of Superwall. When true, Superwall will observe
+   * StoreKit/Play Store transactions and report them. Defaults to false.
+   * @platform iOS and Android
+   */
+  shouldObservePurchases = false
+  /**
+   * Disables the app transaction check on SDK launch. Defaults to false.
+   * @platform iOS only
+   */
+  shouldBypassAppTransactionCheck = false
+  /**
+   * Number of times the SDK will attempt to get the Superwall configuration after
+   * a network failure before it times out. Defaults to 6.
+   * @platform iOS only
+   */
+  maxConfigRetryCount = 6
+  /**
+   * Enable mock review functionality. Defaults to false.
+   * @platform Android only
+   */
+  useMockReviews = false
 
   constructor(init?: Partial<SuperwallOptions>) {
     if (init) {
@@ -92,10 +113,13 @@ export class SuperwallOptions {
       localeIdentifier: this.localeIdentifier,
       isGameControllerEnabled: this.isGameControllerEnabled,
       logging: this.logging.toJson(),
-      collectAdServicesAttribution: this.collectAdServicesAttribution,
       passIdentifiersToPlayStore: this.passIdentifiersToPlayStore,
       storeKitVersion: this.storeKitVersion,
       enableExperimentalDeviceVariables: this.enableExperimentalDeviceVariables,
+      shouldObservePurchases: this.shouldObservePurchases,
+      shouldBypassAppTransactionCheck: this.shouldBypassAppTransactionCheck,
+      maxConfigRetryCount: this.maxConfigRetryCount,
+      useMockReviews: this.useMockReviews,
     })
   }
 }


### PR DESCRIPTION
Add missing SDK configuration options from native iOS and Android SDKs:

- `shouldObservePurchases` (iOS & Android): Observe purchases made outside of Superwall
- `shouldBypassAppTransactionCheck` (iOS only): Disables app transaction check on SDK launch
- `maxConfigRetryCount` (iOS only): Number of retry attempts for config fetch (default: 6)
- `useMockReviews` (Android only): Enable mock review functionality

Also fixes `enableExperimentalDeviceVariables` not being passed to the Android native SDK.

BREAKING CHANGE: Removed deprecated `collectAdServicesAttribution` option
(AdServices attribution is now collected automatically by the native iOS SDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
