### PR TITLE
Adding Superwall log prefixes to better identify logs for devs.

### DIFF
--- a/src/SuperwallProvider.tsx
+++ b/src/SuperwallProvider.tsx
@@ -94,7 +94,7 @@ export function SuperwallProvider({
       const apiKey = apiKeys[Platform.OS as keyof typeof apiKeys]
       if (!apiKey) {
         const error = new Error(`No API key provided for platform ${Platform.OS}`)
-        console.error("Superwall configure failed", error)
+        console.error("[Superwall] Configure failed", error)
         onConfigurationError?.(error)
         return
       }
@@ -134,24 +134,24 @@ export function SuperwallProvider({
         const url = await Linking.getInitialURL()
         if (url && !isExpoDeepLink(url) && !isExpoPlatformUrl(url)) {
           SuperwallExpoModule.handleDeepLink(url).catch((error) => {
-            console.debug("Superwall: Non-Superwall deep link ignored", url, error)
+            console.debug("[Superwall] Non-Superwall deep link ignored", url, error)
           })
         }
       } catch (error) {
-        console.debug("Superwall: Failed to get initial URL", error)
+        console.debug("[Superwall] Failed to get initial URL", error)
       }
 
       deepLinkEventHandlerRef.current = Linking.addEventListener("url", (event) => {
         if (!isExpoDeepLink(event.url) && !isExpoPlatformUrl(event.url)) {
           SuperwallExpoModule.handleDeepLink(event.url).catch((error) => {
-            console.debug("Superwall: Non-Superwall deep link ignored", event.url, error)
+            console.debug("[Superwall] Non-Superwall deep link ignored", event.url, error)
           })
         }
       })
     }
 
     handleDeepLink().catch((error) => {
-      console.error("Superwall: Deep link setup failed", error)
+      console.error("[Superwall] Deep link setup failed", error)
     })
 
     return () => {

--- a/src/compat/lib/SuperwallEventInfo.ts
+++ b/src/compat/lib/SuperwallEventInfo.ts
@@ -385,7 +385,7 @@ export class SuperwallEvent {
           error: json.error,
         })
       default:
-        console.warn(`Unhandled event type in SuperwallEvent.fromJson: ${json.event}`)
+        console.warn(`[Superwall] Unhandled event type in SuperwallEvent.fromJson: ${json.event}`)
         return new SuperwallEvent({ type: eventType }) // Fallback for unhandled but known types
       // For truly unknown types, an error might be more appropriate:
       // throw new Error(`Invalid event type: ${json.event}`);

--- a/src/useSuperwall.ts
+++ b/src/useSuperwall.ts
@@ -348,7 +348,7 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
   _initListeners: (): (() => void) => {
     // Use get() to read the state from within the store
     if (get().listenersInitialized) {
-      console.warn("Listeners already initialized. Skipping.")
+      console.warn("[Superwall] Listeners already initialized. Skipping.")
       return () => {} // Return no-op cleanup
     }
 
@@ -379,10 +379,10 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
     )
 
     set({ listenersInitialized: true })
-    console.log("Initialized listeners", subscriptions.length)
+    console.log("[Superwall] Initialized listeners", subscriptions.length)
 
     return (): void => {
-      console.log("Cleaning up listeners", subscriptions.length)
+      console.log("[Superwall] Cleaning up listeners", subscriptions.length)
       // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach is used for side effects only
       subscriptions.forEach((s) => s.remove())
       // Reset the state on cleanup


### PR DESCRIPTION
Twice now I had some confusion on where certain logs were coming from, which had no identifying information. This made debugging more difficult. This PR simply adds "[Superwall]" as a prefix to all logs, especially non-identifying ones in `useSuperwall.ts`.