### PR TITLE
feat: add setLocaleIdentifier for runtime locale changes

### DIFF
--- a/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
@@ -463,6 +463,10 @@ class SuperwallExpoModule : Module() {
       }
     }
 
+    Function("setLocaleIdentifier") { localeIdentifier: String? ->
+      Superwall.instance.localeIdentifier = localeIdentifier
+    }
+
     AsyncFunction("setIntegrationAttributes") { attributes: Map<String, String>, promise: Promise ->
       scope.launch {
         try {

--- a/ios/SuperwallExpoModule.swift
+++ b/ios/SuperwallExpoModule.swift
@@ -360,6 +360,10 @@ public class SuperwallExpoModule: Module {
       }
     }
 
+    Function("setLocaleIdentifier") { (localeIdentifier: String?) in
+      Superwall.shared.localeIdentifier = localeIdentifier
+    }
+
     AsyncFunction("setIntegrationAttributes") { (attributes: [String: String], promise: Promise) in
       var converted: [IntegrationAttribute: String] = [:]
 

--- a/src/SuperwallExpoModule.ts
+++ b/src/SuperwallExpoModule.ts
@@ -65,6 +65,7 @@ declare class SuperwallExpoModule extends NativeModule<SuperwallExpoModuleEvents
   preloadAllPaywalls(): void
 
   setLogLevel(level: string): void
+  setLocaleIdentifier(localeIdentifier: string | null): void
 
   setIntegrationAttributes(attributes: IntegrationAttributes): Promise<void>
   getIntegrationAttributes(): Promise<Record<string, string>>

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -721,6 +721,17 @@ export default class Superwall {
   }
 
   /**
+   * Sets the locale identifier for the Superwall SDK.
+   * This determines the language used when presenting paywalls.
+   * Can be changed at runtime without needing to reconfigure.
+   *
+   * @param localeIdentifier - The locale identifier (e.g., "en_US", "es_ES"), or `null` to reset to the device locale.
+   */
+  async setLocaleIdentifier(localeIdentifier: string | null): Promise<void> {
+    SuperwallExpoModule.setLocaleIdentifier(localeIdentifier)
+  }
+
+  /**
    * Sets attributes for third-party integrations.
    * @param attributes - Object mapping IntegrationAttribute string values to their IDs
    */

--- a/src/useSuperwall.ts
+++ b/src/useSuperwall.ts
@@ -164,6 +164,15 @@ export interface SuperwallStore {
   setLogLevel: (level: string) => Promise<void>
 
   /**
+   * Sets the locale identifier for the Superwall SDK.
+   * This determines the language used when presenting paywalls.
+   * Can be changed at runtime without needing to reconfigure.
+   * @param localeIdentifier - The locale identifier (e.g., "en", "es", "fr"), or `null` to reset to the device locale.
+   * @returns A promise that resolves when the locale identifier is set.
+   */
+  setLocaleIdentifier: (localeIdentifier: string | null) => Promise<void>
+
+  /**
    * Sets attributes for third-party integrations.
    * @param attributes - Object mapping IntegrationAttribute string values to their IDs
    * @returns A promise that resolves when attributes are set
@@ -319,6 +328,9 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
   },
   setLogLevel: async (level) => {
     SuperwallExpoModule.setLogLevel(level)
+  },
+  setLocaleIdentifier: async (localeIdentifier) => {
+    SuperwallExpoModule.setLocaleIdentifier(localeIdentifier)
   },
 
   setIntegrationAttributes: async (attributes) => {


### PR DESCRIPTION
## Summary

- Expose `setLocaleIdentifier` as a runtime-settable property across all layers (iOS, Android, TS, Zustand store, compat)
- Allows changing the paywall language at runtime without reconfiguring the SDK
- Follows the same pattern as `setLogLevel`

## Problem

Currently, `localeIdentifier` can only be set via `SuperwallOptions` at configure time. Apps that support runtime language switching (e.g., via i18next or user preferences) have no way to update the paywall locale after `configure()` has been called. Since `Superwall.configure` ignores subsequent calls, the only option was to restart the app.

The native SDKs (both iOS and Android) already support setting `localeIdentifier` at runtime via `Superwall.shared.localeIdentifier`, but the Expo wrapper doesn't expose it.

## Changes

| Layer | File | Change |
|-------|------|--------|
| iOS | `SuperwallExpoModule.swift` | `Function("setLocaleIdentifier")` setting `Superwall.shared.localeIdentifier` |
| Android | `SuperwallExpoModule.kt` | `Function("setLocaleIdentifier")` setting `Superwall.instance.localeIdentifier` |
| TS Module | `SuperwallExpoModule.ts` | Type declaration for `setLocaleIdentifier` |
| Zustand Store | `useSuperwall.ts` | Store type + implementation |
| Compat | `compat/index.ts` | Compat wrapper method |

## Usage

```tsx
const { setLocaleIdentifier } = useSuperwall()

// Set to Spanish
setLocaleIdentifier("es")

// Reset to device locale
setLocaleIdentifier(null)
```

## Test plan

- [x] Tested on iOS simulator with Expo — paywalls correctly switch to Spanish after calling `setLocaleIdentifier("es")`
- [x] Android testing

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR exposes a runtime `setLocaleIdentifier` API through the Expo wrapper so apps can change paywall language without re-calling `configure()`. It adds a new JS-exposed function in both native modules (iOS sets `Superwall.shared.localeIdentifier`, Android sets `Superwall.instance.localeIdentifier`), wires the method into the TS native module typing, and surfaces it through both the Zustand hook store and the compat class wrapper.

One correctness issue: the newly-added JS wrapper methods in the compat layer and Zustand store are declared `async` but don’t `await`/`return` the underlying native call, which can cause synchronous native errors (e.g., module unavailable) to be silently swallowed rather than propagated to callers.

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge after fixing the async wrapper error propagation issue.
- Native changes are straightforward property assignments and TS typings align, but the JS wrappers’ `async` methods currently don’t await/return the native call, which can hide failures and make runtime issues hard to diagnose.
- src/compat/index.ts, src/useSuperwall.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt | Adds a new JS-exposed `setLocaleIdentifier` function that assigns `Superwall.instance.localeIdentifier`. |
| ios/SuperwallExpoModule.swift | Adds `setLocaleIdentifier` function to set `Superwall.shared.localeIdentifier` from JS. |
| src/SuperwallExpoModule.ts | Extends the native module type definition with `setLocaleIdentifier(localeIdentifier: string | null): void`. |
| src/compat/index.ts | Adds compat wrapper `setLocaleIdentifier`, but it doesn’t await/return the native call (can swallow synchronous native errors). |
| src/useSuperwall.ts | Adds Zustand store action `setLocaleIdentifier`, but it doesn’t await/return the native call (can swallow synchronous native errors). |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant App as App (JS)
  participant Store as useSuperwall (Zustand)
  participant Compat as compat/Superwall
  participant Expo as SuperwallExpoModule (TS)
  participant IOS as iOS SuperwallExpoModule.swift
  participant Droid as Android SuperwallExpoModule.kt
  participant SDK as Native Superwall SDK

  alt Hooks SDK path
    App->>Store: "setLocaleIdentifier('es')"
    Store->>Expo: "setLocaleIdentifier('es')"
    Expo-->>IOS: "Function(setLocaleIdentifier)"
    IOS->>SDK: "localeIdentifier = 'es'"
    Expo-->>Droid: "Function(setLocaleIdentifier)"
    Droid->>SDK: "localeIdentifier = 'es'"
  else Compat wrapper path
    App->>Compat: "setLocaleIdentifier('es')"
    Compat->>Expo: "setLocaleIdentifier('es')"
    Expo-->>IOS: "Function(setLocaleIdentifier)"
    IOS->>SDK: "localeIdentifier = 'es'"
    Expo-->>Droid: "Function(setLocaleIdentifier)"
    Droid->>SDK: "localeIdentifier = 'es'"
  end
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=bdd5013c-e21b-42a3-a89d-a6258d619e0c))

<!-- /greptile_comment -->