### PR TITLE
Fix "Unhandled event type in SuperwallEvent.fromJson: paywallWebviewProcessTerminated"

### DIFF
--- a/src/compat/lib/SuperwallEventInfo.ts
+++ b/src/compat/lib/SuperwallEventInfo.ts
@@ -136,6 +136,8 @@ export class SuperwallEvent {
   restoreType?: RestoreType
   userAttributes?: Record<string, any>
   audienceFilterParams?: Record<string, any>
+  identifiers?: string[]
+  paywallCount?: number
   count?: number
   duration?: number
   url?: string
@@ -169,6 +171,8 @@ export class SuperwallEvent {
     from?: { status: SubscriptionStatus; entitlements: Entitlement[] }
     to?: { status: SubscriptionStatus; entitlements: Entitlement[] }
     audienceFilterParams?: Record<string, any>
+    identifiers?: string[]
+    paywallCount?: number
     count?: number
     duration?: number
     url?: string
@@ -258,7 +262,6 @@ export class SuperwallEvent {
         return new SuperwallEvent({
           type: eventType,
           paywallCount: json.paywallCount,
-        })
         })
       case EventType.paywallWebviewLoadFail:
         return new SuperwallEvent({


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three new event types (`paywallWebviewProcessTerminated`, `paywallProductsLoadMissingProducts`, `paywallPreloadComplete`) to the compat SDK's `EventType` enum and switch statement to fix "Unhandled event type" errors.

**Major Issues Found:**
- `paywallProductsLoadMissingProducts` and `paywallPreloadComplete` are handled incorrectly in the switch statement - they use the wrong data structure
- Missing class properties: `paywallCount` and `identifiers`
- Missing constructor parameters: `paywallCount` and `identifiers`

The event types are correctly added to the enum and properly supported in iOS (ios/Json/SuperwallPlacementInfo+Json.swift:217-251) and Android (android/src/main/java/expo/modules/superwallexpo/json/SuperwallEvent.kt:261-264), but the TypeScript compat layer implementation doesn't match the native implementations.

<h3>Confidence Score: 2/5</h3>

- This PR has critical logical errors that will cause runtime failures when these events are received
- The implementation is incomplete and incorrect - two of the three new event types will not deserialize properly from native events, causing data loss or runtime errors when `paywallProductsLoadMissingProducts` or `paywallPreloadComplete` events are triggered
- src/compat/lib/SuperwallEventInfo.ts requires fixes to property definitions and switch case handlers

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/compat/lib/SuperwallEventInfo.ts | Added three new event types but implementation is incomplete - missing properties (`paywallCount`, `identifiers`) and incorrect switch case handling for `paywallProductsLoadMissingProducts` and `paywallPreloadComplete` |

</details>



<sub>Last reviewed commit: db609a8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->