### PR TITLE
Fix PromiseAlreadySettledException crash in configure()

### DIFF
--- a/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
@@ -145,6 +145,7 @@ class SuperwallExpoModule : Module() {
       sdkVersion: String?,
       promise: Promise ->
       ioScope.launch {
+        val promiseSettled = java.util.concurrent.atomic.AtomicBoolean(false)
         try{
         val superwallOptions: SuperwallOptions = options?.let {
           superwallOptionsFromJson(options)
@@ -175,13 +176,17 @@ class SuperwallExpoModule : Module() {
           completion = {
             Superwall.instance.setPlatformWrapper("Expo", version = sdkVersion ?: "0.0.0")
             Superwall.instance.delegate = SuperwallDelegateBridge()
-            promise.resolve(true)
+            if (promiseSettled.compareAndSet(false, true)) {
+              promise.resolve(true)
+            }
            }
          )
         } catch (error: Throwable) {
           error.printStackTrace()
-          scope.launch {
-            promise.reject(CodedException(error))
+          if (promiseSettled.compareAndSet(false, true)) {
+            scope.launch {
+              promise.reject(CodedException(error))
+            }
           }
         }
       }

--- a/ios/SuperwallExpoModule.swift
+++ b/ios/SuperwallExpoModule.swift
@@ -1,6 +1,22 @@
 import ExpoModulesCore
 import SuperwallKit
 
+/// Thread-safe boolean flag that can only be set once.
+private final class AtomicFlag {
+  private var _value = false
+  private let lock = NSLock()
+
+  /// Sets the flag and returns the previous value.
+  /// Returns `false` on the first call, `true` on subsequent calls.
+  func testAndSet() -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    let prev = _value
+    _value = true
+    return prev
+  }
+}
+
 public class SuperwallExpoModule: Module {
   public static var shared: SuperwallExpoModule?
 
@@ -102,6 +118,8 @@ public class SuperwallExpoModule: Module {
         superwallOptions = SuperwallOptions.fromJson(options)
       }
 
+      let promiseSettled = AtomicFlag()
+
       Superwall.configure(
         apiKey: apiKey,
         purchaseController: usingPurchaseController ? purchaseController : nil,
@@ -112,7 +130,9 @@ public class SuperwallExpoModule: Module {
 
           Superwall.shared.setPlatformWrapper("Expo", version: sdkVersion ?? "0.0.0")
 
-          promise.resolve(nil)
+          if promiseSettled.testAndSet() == false {
+            promise.resolve(nil)
+          }
         }
       )
     }


### PR DESCRIPTION
## Summary

- Fixes a fatal `PromiseAlreadySettledException` crash on Android during `Superwall.configure()` when the SDK's completion callback fires more than once
- Guards promise settlement with an atomic flag on both Android (`AtomicBoolean`) and iOS (`NSLock`-based `AtomicFlag`) so only the first callback invocation resolves the promise
- Applies the same defensive fix on iOS to prevent the equivalent crash there

## Context

Crashlytics issue `96d79ec9f4b0acedd655e1d147e00ef6` from app `com.quittrapp.quittr_mobile_application_2` (v1.5.2). The native SDK's `configure()` completion can be invoked multiple times (e.g. on config refresh), but Expo promises are single-use — the second `promise.resolve()` call throws `PromiseAlreadySettledException`.

## Test plan

- [ ] Verify `configure()` resolves successfully on first call
- [ ] Verify no crash if the native SDK invokes the completion callback more than once
- [ ] Verify error path still rejects the promise correctly
- [ ] Run on both Android and iOS


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `PromiseAlreadySettledException` crash on Android (and preemptively on iOS) by guarding Expo promise settlement with an atomic flag, preventing double-resolution when the Superwall SDK's `configure()` completion callback fires more than once (e.g., on config refresh).

- **Android**: An `AtomicBoolean` created per `configure()` invocation uses `compareAndSet(false, true)` to ensure only the first completion callback invocation resolves the promise, and only the first synchronous exception rejects it.
- **iOS**: A new private `AtomicFlag` class backed by `NSLock` provides equivalent `testAndSet()` semantics, guarding `promise.resolve(nil)` in the completion callback.
- Both implementations are semantically correct and consistent with each other.
- **Side effect concern**: `setPlatformWrapper` and `SuperwallDelegateBridge()` instantiation/assignment run on every subsequent completion call (outside the guard), not just the first. While harmless today due to the delegate being stateless, it is cleaner to scope these inside the guard.
- **iOS missing rejection path**: Unlike Android (which has a `try/catch` that rejects the promise on synchronous errors), the iOS `configure` implementation has no fallback to reject the promise if the completion block is never called. If `Superwall.configure` can exit without invoking the completion, the JS caller would hang indefinitely.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge and correctly fixes the reported crash; two minor non-blocking issues remain.
- The atomic guarding logic on both platforms is correct. The `compareAndSet`/`testAndSet` semantics properly ensure exactly-once promise settlement. The only issues are a style concern (setup side-effects outside the guard) and a pre-existing gap on iOS (no synchronous error rejection path), neither of which would regress existing behavior or introduce new crashes.
- `ios/SuperwallExpoModule.swift` — consider adding a `do-catch` wrapper around `Superwall.configure` to handle the case where the completion is never invoked.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt | Adds an `AtomicBoolean` guard to prevent `PromiseAlreadySettledException` in the `configure()` completion callback. The atomic semantics are correct. Minor: delegate setup and `setPlatformWrapper` still run on every subsequent completion call. |
| ios/SuperwallExpoModule.swift | Adds a custom `AtomicFlag` (NSLock-backed) to guard promise settlement on iOS. The `testAndSet` semantics are correct and consistent with the Android side. Two issues: side effects (delegate creation, setPlatformWrapper) run on every completion; and there is no synchronous error-catching path to reject the promise if `configure` faults before calling the completion block. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant JS as JS / Expo
    participant Module as SuperwallExpoModule
    participant Flag as AtomicFlag / AtomicBoolean
    participant SDK as Superwall SDK

    JS->>Module: configure(apiKey, ...)
    Module->>Flag: create (value=false)
    Module->>SDK: Superwall.configure(completion: ...)

    SDK-->>Module: completion() [1st call — initial config]
    Module->>Flag: testAndSet() / compareAndSet(false,true) → false/true
    Flag-->>Module: first call confirmed
    Module->>Module: setPlatformWrapper + setDelegate
    Module-->>JS: promise.resolve()

    SDK-->>Module: completion() [2nd call — config refresh]
    Module->>Flag: testAndSet() / compareAndSet(false,true) → true/false
    Flag-->>Module: already settled — skip
    Note over Module,JS: promise NOT resolved again (crash prevented)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `ios/SuperwallExpoModule.swift`, line 127-136 ([link](https://github.com/superwall/expo-superwall/blob/6f522ca3ee14df02a27d6f93a3cd1a46dba524df/ios/SuperwallExpoModule.swift#L127-L136)) 

   **Side effects run on every completion invocation (iOS)**

   `self.delegate = SuperwallDelegateBridge()`, `Superwall.shared.delegate = self.delegate`, and `setPlatformWrapper` are all called on every subsequent `completion` invocation (e.g., config refresh), not just the first. While functionally safe today (since `SuperwallDelegateBridge` is stateless), each refresh unnecessarily allocates a new bridge instance and immediately discards the previous one.

   Consider moving the setup inside the guard:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: ios/SuperwallExpoModule.swift
   Line: 127-136

   Comment:
   **Side effects run on every completion invocation (iOS)**

   `self.delegate = SuperwallDelegateBridge()`, `Superwall.shared.delegate = self.delegate`, and `setPlatformWrapper` are all called on every subsequent `completion` invocation (e.g., config refresh), not just the first. While functionally safe today (since `SuperwallDelegateBridge` is stateless), each refresh unnecessarily allocates a new bridge instance and immediately discards the previous one.

   Consider moving the setup inside the guard:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `ios/SuperwallExpoModule.swift`, line 106-138 ([link](https://github.com/superwall/expo-superwall/blob/6f522ca3ee14df02a27d6f93a3cd1a46dba524df/ios/SuperwallExpoModule.swift#L106-L138)) 

   **No rejection path if `configure` fails synchronously on iOS**

   The iOS `configure` implementation has no `do-try-catch` wrapper around `Superwall.configure(...)`. The Android implementation has a `try/catch` that rejects the promise if an exception is thrown before or during the configure call. On iOS, if `Superwall.configure` throws or faults synchronously (before ever invoking the `completion` block), the `promise` is never settled, leaving the calling JS code hanging indefinitely.

   If `Superwall.configure` on iOS is guaranteed to always call the `completion` callback (even on failure), this may be intentional. But if there is any code path that exits without calling `completion`, a `do-catch` wrapper — matching the Android approach — would prevent a promise leak:

   ```swift
   do {
     Superwall.configure(
       apiKey: apiKey,
       purchaseController: usingPurchaseController ? purchaseController : nil,
       options: superwallOptions,
       completion: { ... }
     )
   } catch {
     if promiseSettled.testAndSet() == false {
       promise.reject(error)
     }
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: ios/SuperwallExpoModule.swift
   Line: 106-138

   Comment:
   **No rejection path if `configure` fails synchronously on iOS**

   The iOS `configure` implementation has no `do-try-catch` wrapper around `Superwall.configure(...)`. The Android implementation has a `try/catch` that rejects the promise if an exception is thrown before or during the configure call. On iOS, if `Superwall.configure` throws or faults synchronously (before ever invoking the `completion` block), the `promise` is never settled, leaving the calling JS code hanging indefinitely.

   If `Superwall.configure` on iOS is guaranteed to always call the `completion` callback (even on failure), this may be intentional. But if there is any code path that exits without calling `completion`, a `do-catch` wrapper — matching the Android approach — would prevent a promise leak:

   ```swift
   do {
     Superwall.configure(
       apiKey: apiKey,
       purchaseController: usingPurchaseController ? purchaseController : nil,
       options: superwallOptions,
       completion: { ... }
     )
   } catch {
     if promiseSettled.testAndSet() == false {
       promise.reject(error)
     }
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
Line: 176-183

Comment:
**Side effects run on every completion invocation**

`setPlatformWrapper` and `delegate` assignment are intentionally outside the atomic guard, so they execute on every subsequent `completion` call (e.g., config refresh). While currently harmless — `SuperwallDelegateBridge` is stateless and just forwards events through the module's singleton — it creates a fresh delegate instance that immediately replaces the previous one on every refresh, which is unnecessary work.

Consider moving those operations inside the guard so they only execute once:

```suggestion
          completion = {
            if (promiseSettled.compareAndSet(false, true)) {
              Superwall.instance.setPlatformWrapper("Expo", version = sdkVersion ?: "0.0.0")
              Superwall.instance.delegate = SuperwallDelegateBridge()
              promise.resolve(true)
            }
           }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: ios/SuperwallExpoModule.swift
Line: 127-136

Comment:
**Side effects run on every completion invocation (iOS)**

`self.delegate = SuperwallDelegateBridge()`, `Superwall.shared.delegate = self.delegate`, and `setPlatformWrapper` are all called on every subsequent `completion` invocation (e.g., config refresh), not just the first. While functionally safe today (since `SuperwallDelegateBridge` is stateless), each refresh unnecessarily allocates a new bridge instance and immediately discards the previous one.

Consider moving the setup inside the guard:

```suggestion
        completion: {
          if promiseSettled.testAndSet() == false {
            self.delegate = SuperwallDelegateBridge()
            Superwall.shared.delegate = self.delegate

            Superwall.shared.setPlatformWrapper("Expo", version: sdkVersion ?? "0.0.0")

            promise.resolve(nil)
          }
        }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: ios/SuperwallExpoModule.swift
Line: 106-138

Comment:
**No rejection path if `configure` fails synchronously on iOS**

The iOS `configure` implementation has no `do-try-catch` wrapper around `Superwall.configure(...)`. The Android implementation has a `try/catch` that rejects the promise if an exception is thrown before or during the configure call. On iOS, if `Superwall.configure` throws or faults synchronously (before ever invoking the `completion` block), the `promise` is never settled, leaving the calling JS code hanging indefinitely.

If `Superwall.configure` on iOS is guaranteed to always call the `completion` callback (even on failure), this may be intentional. But if there is any code path that exits without calling `completion`, a `do-catch` wrapper — matching the Android approach — would prevent a promise leak:

```swift
do {
  Superwall.configure(
    apiKey: apiKey,
    purchaseController: usingPurchaseController ? purchaseController : nil,
    options: superwallOptions,
    completion: { ... }
  )
} catch {
  if promiseSettled.testAndSet() == false {
    promise.reject(error)
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 6f522ca</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->