### PR TITLE
Expose restorePurchases() in the Expo bridge

### DIFF
--- a/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
@@ -426,7 +426,7 @@ class SuperwallExpoModule : Module() {
           }
         }, { error ->
           scope.launch {
-            promise.reject(CodedException(error))
+            promise.resolve(restorationResultToJson(RestorationResult.Failed(error)))
           }
         })
       }

--- a/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
@@ -418,6 +418,20 @@ class SuperwallExpoModule : Module() {
       promise.resolve(null)
     }
 
+    AsyncFunction("restorePurchases") { promise: Promise ->
+      ioScope.launch {
+        Superwall.instance.restorePurchases().fold({ result ->
+          scope.launch {
+            promise.resolve(restorationResultToJson(result))
+          }
+        }, { error ->
+          scope.launch {
+            promise.reject(CodedException(error))
+          }
+        })
+      }
+    }
+
     AsyncFunction("dismiss") { promise: Promise ->
       ioScope.launch {
         Superwall.instance.dismiss()

--- a/android/src/main/java/expo/modules/superwallexpo/json/RestorationResult.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/json/RestorationResult.kt
@@ -13,3 +13,13 @@ fun restorationResultFromJson(json: Map<String, Any>): RestorationResult {
         else -> RestorationResult.Failed(Error("Unknown restoration result"))
       }
 }
+
+fun restorationResultToJson(result: RestorationResult): Map<String, Any?> {
+    return when (result) {
+        is RestorationResult.Restored -> mapOf("result" to "restored")
+        is RestorationResult.Failed -> mapOf(
+            "result" to "failed",
+            "errorMessage" to (result.error?.message ?: "Unknown error")
+        )
+    }
+}

--- a/ios/Json/RestorationResult+Json.swift
+++ b/ios/Json/RestorationResult+Json.swift
@@ -21,4 +21,13 @@ extension RestorationResult {
       return nil
     }
   }
+
+  func toJson() -> [String: Any] {
+    switch self {
+    case .restored:
+      return ["result": "restored"]
+    case .failed(let error):
+      return ["result": "failed", "errorMessage": error?.localizedDescription ?? "Unknown error"]
+    }
+  }
 }

--- a/ios/SuperwallExpoModule.swift
+++ b/ios/SuperwallExpoModule.swift
@@ -346,6 +346,13 @@ public class SuperwallExpoModule: Module {
       promise.resolve(nil)
     }
 
+    AsyncFunction("restorePurchases") { (promise: Promise) in
+      Task {
+        let result = await Superwall.shared.restorePurchases()
+        promise.resolve(result.toJson())
+      }
+    }
+
     AsyncFunction("dismiss") { (promise: Promise) in
       Superwall.shared.dismiss {
         promise.resolve(nil)

--- a/src/SuperwallExpoModule.ts
+++ b/src/SuperwallExpoModule.ts
@@ -2,6 +2,7 @@ import { NativeModule, requireNativeModule } from "expo"
 import type {
   EntitlementsInfo,
   IntegrationAttributes,
+  RestorationResult,
   SuperwallExpoModuleEvents,
 } from "./SuperwallExpoModule.types"
 
@@ -50,6 +51,8 @@ declare class SuperwallExpoModule extends NativeModule<SuperwallExpoModuleEvents
   didRestore(result: Record<string, any>): void
   didHandleBackPressed(shouldConsume: boolean): void
   didHandleCustomCallback(callbackId: string, status: string, data?: Record<string, any>): Promise<void>
+
+  restorePurchases(): Promise<RestorationResult>
 
   dismiss(): Promise<void>
   confirmAllAssignments(): Promise<any[]>

--- a/src/SuperwallExpoModule.ts
+++ b/src/SuperwallExpoModule.ts
@@ -2,7 +2,7 @@ import { NativeModule, requireNativeModule } from "expo"
 import type {
   EntitlementsInfo,
   IntegrationAttributes,
-  RestorationResult,
+  RestorationResultResponse,
   SuperwallExpoModuleEvents,
 } from "./SuperwallExpoModule.types"
 
@@ -52,7 +52,7 @@ declare class SuperwallExpoModule extends NativeModule<SuperwallExpoModuleEvents
   didHandleBackPressed(shouldConsume: boolean): void
   didHandleCustomCallback(callbackId: string, status: string, data?: Record<string, any>): Promise<void>
 
-  restorePurchases(): Promise<RestorationResult>
+  restorePurchases(): Promise<RestorationResultResponse>
 
   dismiss(): Promise<void>
   confirmAllAssignments(): Promise<any[]>

--- a/src/SuperwallExpoModule.types.ts
+++ b/src/SuperwallExpoModule.types.ts
@@ -2338,9 +2338,9 @@ export type OnPurchaseParams = OnPurchaseParamsIOS | OnPurchaseParamsAndroid
  * - `restored`: The restoration completed successfully.
  * - `failed`: The restoration failed, with an accompanying error message.
  */
-export type RestorationResult =
+export type RestorationResultResponse =
   | { result: "restored" }
-  | { result: "failed"; errorMessage: string }
+  | { result: "failed"; errorMessage: string | null }
 
 /**
  * Defines the events emitted by the native Superwall Expo module that can be listened to.

--- a/src/SuperwallExpoModule.types.ts
+++ b/src/SuperwallExpoModule.types.ts
@@ -2334,6 +2334,15 @@ export type OnPurchaseParamsAndroid = {
 export type OnPurchaseParams = OnPurchaseParamsIOS | OnPurchaseParamsAndroid
 
 /**
+ * Represents the result of a purchase restoration attempt.
+ * - `restored`: The restoration completed successfully.
+ * - `failed`: The restoration failed, with an accompanying error message.
+ */
+export type RestorationResult =
+  | { result: "restored" }
+  | { result: "failed"; errorMessage: string }
+
+/**
  * Defines the events emitted by the native Superwall Expo module that can be listened to.
  * These events provide a way to react to various SDK activities and user interactions.
  * Use `SuperwallExpoModule.addListener(eventName, callback)` to subscribe.

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -22,7 +22,7 @@ export { PaywallResult } from "./lib/PaywallResult"
 import { EventEmitter } from "expo"
 import { version } from "../../package.json"
 import SuperwallExpoModule from "../SuperwallExpoModule"
-import type { RestorationResult as RestorationResultJson } from "../SuperwallExpoModule.types"
+import type { RestorationResultResponse } from "../SuperwallExpoModule.types"
 import { filterUndefined } from "../utils/filterUndefined"
 
 export { ComputedPropertyRequest } from "./lib/ComputedPropertyRequest"
@@ -61,6 +61,7 @@ export {
 } from "./lib/PurchaseResult"
 export * from "./lib/RedemptionResults"
 export { RestorationResult } from "./lib/RestorationResult"
+export type { RestorationResultResponse } from "../SuperwallExpoModule.types"
 export { RestoreType } from "./lib/RestoreType"
 export { StoreProduct } from "./lib/StoreProduct"
 export { StoreTransaction } from "./lib/StoreTransaction"
@@ -714,9 +715,9 @@ export default class Superwall {
    * Use this to trigger a restore from outside a paywall context,
    * e.g. from a "Restore Purchases" button in app settings.
    *
-   * @returns {Promise<RestorationResultJson>} A promise that resolves with the restoration result.
+   * @returns {Promise<RestorationResultResponse>} A promise that resolves with the restoration result.
    */
-  async restorePurchases(): Promise<RestorationResultJson> {
+  async restorePurchases(): Promise<RestorationResultResponse> {
     await this.awaitConfig()
     return await SuperwallExpoModule.restorePurchases()
   }

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -22,6 +22,7 @@ export { PaywallResult } from "./lib/PaywallResult"
 import { EventEmitter } from "expo"
 import { version } from "../../package.json"
 import SuperwallExpoModule from "../SuperwallExpoModule"
+import type { RestorationResult as RestorationResultJson } from "../SuperwallExpoModule.types"
 import { filterUndefined } from "../utils/filterUndefined"
 
 export { ComputedPropertyRequest } from "./lib/ComputedPropertyRequest"
@@ -705,6 +706,19 @@ export default class Superwall {
   async setUserAttributes(userAttributes: UserAttributes): Promise<void> {
     await this.awaitConfig()
     await SuperwallExpoModule.setUserAttributes(filterUndefined(userAttributes))
+  }
+
+  /**
+   * Programmatically restores purchases.
+   *
+   * Use this to trigger a restore from outside a paywall context,
+   * e.g. from a "Restore Purchases" button in app settings.
+   *
+   * @returns {Promise<RestorationResultJson>} A promise that resolves with the restoration result.
+   */
+  async restorePurchases(): Promise<RestorationResultJson> {
+    await this.awaitConfig()
+    return await SuperwallExpoModule.restorePurchases()
   }
 
   /**

--- a/src/useSuperwall.ts
+++ b/src/useSuperwall.ts
@@ -6,6 +6,7 @@ import SuperwallExpoModule from "./SuperwallExpoModule"
 import type {
   EntitlementsInfo,
   IntegrationAttributes,
+  RestorationResult,
   SubscriptionStatus,
 } from "./SuperwallExpoModule.types"
 import { DefaultSuperwallOptions, type PartialSuperwallOptions } from "./SuperwallOptions"
@@ -127,6 +128,12 @@ export interface SuperwallStore {
    * @returns A promise that resolves with the presentation result.
    */
   getPresentationResult: (placement: string, params?: Record<string, any>) => Promise<any>
+  /**
+   * Programmatically restores purchases.
+   * @returns A promise that resolves with a {@link RestorationResult} indicating success or failure.
+   */
+  restorePurchases: () => Promise<RestorationResult>
+
   /**
    * Dismisses any currently presented Superwall paywall.
    * @returns A promise that resolves when the dismissal is complete.
@@ -297,6 +304,9 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
   },
   getPresentationResult: async (placement, params) => {
     return SuperwallExpoModule.getPresentationResult(placement, params)
+  },
+  restorePurchases: async () => {
+    return SuperwallExpoModule.restorePurchases()
   },
   dismiss: async () => {
     await SuperwallExpoModule.dismiss()

--- a/src/useSuperwall.ts
+++ b/src/useSuperwall.ts
@@ -6,7 +6,7 @@ import SuperwallExpoModule from "./SuperwallExpoModule"
 import type {
   EntitlementsInfo,
   IntegrationAttributes,
-  RestorationResult,
+  RestorationResultResponse,
   SubscriptionStatus,
 } from "./SuperwallExpoModule.types"
 import { DefaultSuperwallOptions, type PartialSuperwallOptions } from "./SuperwallOptions"
@@ -130,9 +130,9 @@ export interface SuperwallStore {
   getPresentationResult: (placement: string, params?: Record<string, any>) => Promise<any>
   /**
    * Programmatically restores purchases.
-   * @returns A promise that resolves with a {@link RestorationResult} indicating success or failure.
+   * @returns A promise that resolves with a {@link RestorationResultResponse} indicating success or failure.
    */
-  restorePurchases: () => Promise<RestorationResult>
+  restorePurchases: () => Promise<RestorationResultResponse>
 
   /**
    * Dismisses any currently presented Superwall paywall.


### PR DESCRIPTION
## Summary

- Exposes `restorePurchases()` across iOS, Android, and TypeScript layers, allowing programmatic purchase restoration from JavaScript (e.g., a "Restore Purchases" button in app settings)
- Adds `RestorationResult` type as a discriminated union (`restored` | `failed`) to the TypeScript type system
- Adds the method to both the hooks SDK (`useSuperwall`) and the compat SDK (`Superwall` class)

## Test plan

- [ ] Verify iOS build compiles with the new `AsyncFunction` and `toJson()` extension
- [ ] Verify Android build compiles with the new `AsyncFunction` and `restorationResultToJson()`
- [ ] Call `restorePurchases()` from JS and confirm it returns `{ result: "restored" }` on success
- [ ] Call `restorePurchases()` from JS and confirm it returns `{ result: "failed", errorMessage: "..." }` on failure
- [ ] Verify compat SDK `Superwall.restorePurchases()` works with `awaitConfig()` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes `restorePurchases()` across iOS, Android, and TypeScript, adding a `RestorationResult` discriminated union type and wiring it into both the hooks SDK (`useSuperwall`) and the compat SDK (`Superwall` class). The native implementations are straightforward and follow established patterns in the module.

**Key concerns found during review:**

- **`RestorationResult` naming collision (P1):** `src/SuperwallExpoModule.types.ts` introduces a new `RestorationResult` discriminated union type that is now publicly exported from `src/index.ts` via `export type *`. However, `src/compat/lib/RestorationResult.ts` already exports an abstract `RestorationResult` class (with `Restored`/`Failed` subclasses) from `src/compat/index.ts`. These two types have the same name but different structures — notably, `Failed.toJson()` in the compat class returns `errorMessage: null`, while the new type declares `errorMessage: string`. This risks confusing consumers who try to type-annotate `Superwall.restorePurchases()` results using the compat-exported class.
- **Android platform inconsistency (P1):** The Android bridge rejects the promise when `restorePurchases()` returns `Result.failure(exception)`, whereas iOS always resolves. The TypeScript signature `Promise<RestorationResult>` implies the promise always resolves on both platforms, making this silent divergence a potential source of unhandled rejections on Android.
- **Undiscoverable return type in compat SDK (P2):** The `RestorationResultJson` alias used as the compat `restorePurchases()` return type is not re-exported from the compat entry point, making it difficult for compat SDK consumers to type-annotate the resolved value.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge with minor risk — the naming collision is a public API concern and the Android rejection path is a cross-platform inconsistency, but neither causes a crash in the common case.
- Native implementations are correct and follow existing module patterns. The two flagged P1 issues are real but unlikely to cause immediate runtime failures in typical usage (the Android `Result.failure` path is an edge case, and the type naming collision is a DX/discoverability issue rather than a runtime bug). Resolving these before wider release is recommended.
- `src/SuperwallExpoModule.types.ts` (naming collision) and `android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt` (promise rejection vs resolution inconsistency with iOS).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/SuperwallExpoModule.types.ts | Adds new `RestorationResult` discriminated union type — creates a naming collision with the existing abstract `RestorationResult` class exported from `src/compat/lib/RestorationResult.ts`, and the two types have structurally different shapes for the `failed` case. |
| android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt | Adds `restorePurchases` `AsyncFunction` using `.fold()` on the SDK result; the failure branch rejects the promise rather than resolving with a `failed` shape, creating a platform behavioral inconsistency with iOS. |
| android/src/main/java/expo/modules/superwallexpo/json/RestorationResult.kt | Adds `restorationResultToJson` helper — correct and symmetric with `restorationResultFromJson`. |
| ios/Json/RestorationResult+Json.swift | Adds `toJson()` extension on `RestorationResult` — clean and consistent with the existing `fromJson` static method. |
| ios/SuperwallExpoModule.swift | Adds `restorePurchases` `AsyncFunction` wrapping `Superwall.shared.restorePurchases()` in a Swift `Task`; always resolves the promise, matching the TypeScript contract. |
| src/SuperwallExpoModule.ts | Adds `restorePurchases(): Promise<RestorationResult>` declaration to the native module interface — straightforward and correctly typed. |
| src/compat/index.ts | Adds `restorePurchases()` to the compat `Superwall` class with `awaitConfig()` guard; however `RestorationResultJson` is an unexported alias making the return type undiscoverable for compat SDK consumers. |
| src/useSuperwall.ts | Adds `restorePurchases` to `SuperwallStore` interface and implementation — consistent with other store methods in pattern (no `awaitConfig()`, directly delegating to the native module). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant JS as JavaScript (useSuperwall / Superwall class)
    participant Bridge as Expo Native Bridge
    participant iOS as iOS (SuperwallKit)
    participant Android as Android (Superwall SDK)

    JS->>Bridge: restorePurchases()
    alt iOS
        Bridge->>iOS: Superwall.shared.restorePurchases()
        iOS-->>Bridge: RestorationResult (.restored | .failed)
        Bridge->>Bridge: result.toJson()
        Bridge-->>JS: Promise.resolve({ result: "restored" | "failed", errorMessage? })
    else Android
        Bridge->>Android: Superwall.instance.restorePurchases()
        Android-->>Bridge: Result<RestorationResult>
        alt Result.success
            Bridge->>Bridge: restorationResultToJson(result)
            Bridge-->>JS: Promise.resolve({ result: "restored" | "failed", errorMessage? })
        else Result.failure (unexpected exception)
            Bridge-->>JS: Promise.reject(CodedException)
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/SuperwallExpoModule.types.ts
Line: 2336-2343

Comment:
**Naming collision with existing `RestorationResult` class**

There is already an exported `RestorationResult` abstract class in `src/compat/lib/RestorationResult.ts` (re-exported from `src/compat/index.ts`). This new discriminated union type has the same name but a structurally different shape — notably the compat class's `Failed.toJson()` returns `errorMessage: null` when no error is present, whereas this new type declares `errorMessage: string` (never null).

Because `src/index.ts` uses `export type * from "./SuperwallExpoModule.types"`, this discriminated union will now be publicly exported from the main package entry point under the same name as the compat class. Consumers of the compat SDK who call `Superwall.restorePurchases()` will want to annotate its `Promise<RestorationResultJson>` return, but the most naturally discoverable `RestorationResult` in scope (from the compat path) is the abstract class — leading to a type mismatch. Consider naming this something distinct like `RestorationResultRaw` or `RestorationResultData` to avoid the collision.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
Line: 421-433

Comment:
**Platform inconsistency: Android can reject while iOS always resolves**

On iOS, `restorePurchases()` returns a `RestorationResult` value directly; the promise always resolves (with `{ result: "restored" }` or `{ result: "failed", ... }`). On Android, the `.fold()` failure branch calls `promise.reject(CodedException(error))`, meaning if the native SDK wraps an unexpected exception in `Result.failure(...)`, the JS promise rejects rather than resolves.

The TypeScript return type `Promise<RestorationResult>` implies the promise always resolves on both platforms. A caller who writes:

```kotlin
const result = await superwall.restorePurchases()
// assumes result.result === "restored" | "failed"
```

…will see an unhandled exception on Android in unexpected failure scenarios rather than a `{ result: "failed" }` object.

Consider aligning platforms so that any Android-side exception is converted into a `RestorationResult.Failed` shape (resolved, not rejected), mirroring iOS's behavior.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/compat/index.ts
Line: 25

Comment:
**`RestorationResultJson` alias not re-exported from compat**

`RestorationResultJson` is used as the return type of the compat `restorePurchases()` method but is only an internal import alias — it is not exported from the compat entry point. A consumer of `Superwall.restorePurchases()` who needs to annotate the resolved type cannot conveniently import it from the compat path.

Since the same `RestorationResult` name is already taken in this module by the abstract class, either:
1. Export it under a distinct name (e.g., `export type { RestorationResult as RestorationResultResponse } from "../SuperwallExpoModule.types"`), or
2. Resolve the naming collision described in the `SuperwallExpoModule.types.ts` comment and re-export the type here.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["Expose restorePurcha..."](https://github.com/superwall/expo-superwall/commit/dd8574165b0e00fe6acb28f6ffb6c109af09db24)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->