### PR TITLE
Fix placement event scoping and SDK state parity

### DIFF
--- a/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
@@ -291,19 +291,11 @@ class SuperwallExpoModule : Module() {
     AsyncFunction("getEntitlements") { promise: Promise ->
       try {
         val entitlements = Superwall.instance.entitlements
-        val map = mutableMapOf<String, List<Map<String, String>>>()
-        
-        map["all"] = entitlements.all.map { entitlement ->
-          mapOf("id" to entitlement.id)
-        }
-        
-        map["inactive"] = entitlements.inactive.map { entitlement ->
-          mapOf("id" to entitlement.id)
-        }
-        
-        map["active"] = entitlements.active.map { entitlement ->
-          mapOf("id" to entitlement.id)
-        }
+        val map = mutableMapOf<String, List<Map<String, Any>>>()
+
+        map["all"] = entitlements.all.toJson()
+        map["inactive"] = entitlements.inactive.toJson()
+        map["active"] = entitlements.active.toJson()
         promise.resolve(map)
       } catch (error: Exception) {
         promise.reject(CodedException(error))

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  ...require("expo-module-scripts/jest-preset-plugin"),
+  modulePathIgnorePatterns: ["<rootDir>/build/"],
+  moduleNameMapper: {
+    "^react$": "<rootDir>/example/node_modules/react",
+    "^react/jsx-runtime$": "<rootDir>/example/node_modules/react/jsx-runtime",
+    "^react/jsx-dev-runtime$": "<rootDir>/example/node_modules/react/jsx-dev-runtime",
+  },
+  testPathIgnorePatterns: ["<rootDir>/build/", "<rootDir>/example/", "<rootDir>/ui_test_app/"],
+}

--- a/src/SuperwallExpoModule.types.ts
+++ b/src/SuperwallExpoModule.types.ts
@@ -130,6 +130,11 @@ export type IntegrationAttributes = {
  */
 export interface EntitlementsInfo {
   /**
+   * Array of all entitlements known for the user.
+   * Present when the native bridge exposes the full entitlement set.
+   */
+  all?: Entitlement[]
+  /**
    * Array of entitlements that are currently active for the user.
    * See {@link Entitlement}.
    */

--- a/src/SuperwallProvider.tsx
+++ b/src/SuperwallProvider.tsx
@@ -99,9 +99,13 @@ export function SuperwallProvider({
     if (!isConfigured && !isLoading && !configurationError) {
       const apiKey = apiKeys[Platform.OS as keyof typeof apiKeys]
       if (!apiKey) {
-        const error = new Error(`No API key provided for platform ${Platform.OS}`)
-        console.error("[Superwall] Configure failed", error)
-        onConfigurationError?.(error)
+        const errorMessage = `No API key provided for platform ${Platform.OS}`
+        console.error("[Superwall] Configure failed", new Error(errorMessage))
+        useSuperwallStore.setState({
+          isConfigured: false,
+          isLoading: false,
+          configurationError: errorMessage,
+        })
         return
       }
 
@@ -118,7 +122,6 @@ export function SuperwallProvider({
     apiKeys,
     options,
     configure,
-    onConfigurationError,
   ])
 
   // Notify callback when configuration error changes

--- a/src/__tests__/sdk.behavior.test.tsx
+++ b/src/__tests__/sdk.behavior.test.tsx
@@ -1,0 +1,305 @@
+import React from "react"
+import TestRenderer, { act } from "react-test-renderer"
+
+const mockListeners = new Map<string, Set<(payload: any) => void>>()
+const mockHandleDeepLink = jest.fn().mockResolvedValue(false)
+const mockDidHandleBackPressed = jest.fn()
+const mockDidHandleCustomCallback = jest.fn().mockResolvedValue(undefined)
+const mockAddListener = jest.fn(
+  (eventName: string, listener: (payload: any) => void): { remove: () => void } => {
+    const listeners = mockListeners.get(eventName) ?? new Set()
+    listeners.add(listener)
+    mockListeners.set(eventName, listeners)
+
+    return {
+      remove: () => {
+        listeners.delete(listener)
+        if (listeners.size === 0) {
+          mockListeners.delete(eventName)
+        }
+      },
+    }
+  },
+)
+
+const emit = (eventName: string, payload: any) => {
+  const listeners = mockListeners.get(eventName)
+  if (!listeners) return
+  listeners.forEach((listener) => listener(payload))
+}
+
+jest.mock("../SuperwallExpoModule", () => ({
+  __esModule: true,
+  default: {
+    addListener: mockAddListener,
+    handleDeepLink: mockHandleDeepLink,
+    didHandleBackPressed: mockDidHandleBackPressed,
+    didHandleCustomCallback: mockDidHandleCustomCallback,
+  },
+}))
+
+const mockGetInitialURL = jest.fn().mockResolvedValue(null)
+const mockAddLinkingListener = jest.fn(() => ({ remove: jest.fn() }))
+
+jest.mock("react-native", () => {
+  return {
+    Platform: {
+      OS: "ios",
+    },
+    Linking: {
+      getInitialURL: mockGetInitialURL,
+      addEventListener: mockAddLinkingListener,
+    },
+  }
+})
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const { SuperwallProvider }: typeof import("../SuperwallProvider") = require("../SuperwallProvider")
+const { SuperwallContext, useSuperwallStore }: typeof import("../useSuperwall") = require("../useSuperwall")
+const { usePlacement }: typeof import("../usePlacement") = require("../usePlacement")
+const { useSuperwallEvents }: typeof import("../useSuperwallEvents") =
+  require("../useSuperwallEvents")
+
+describe("SDK behavior regressions", () => {
+  let consoleErrorSpy: jest.SpyInstance
+  let consoleLogSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    mockListeners.clear()
+    jest.clearAllMocks()
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {})
+    useSuperwallStore.setState({
+      isConfigured: false,
+      isLoading: false,
+      listenersInitialized: false,
+      configurationError: null,
+      user: null,
+      subscriptionStatus: { status: "UNKNOWN" },
+    })
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+    consoleLogSpy.mockRestore()
+  })
+
+  it("scopes onPaywallError by handlerId while keeping global listeners unscoped", () => {
+    const scopedError = jest.fn()
+    const globalError = jest.fn()
+
+    function ScopedHarness() {
+      useSuperwallEvents({
+        handlerId: "placement-a",
+        onPaywallError: scopedError,
+      })
+      return null
+    }
+
+    function GlobalHarness() {
+      useSuperwallEvents({
+        onPaywallError: globalError,
+      })
+      return null
+    }
+
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        <>
+          <ScopedHarness />
+          <GlobalHarness />
+        </>,
+      )
+    })
+
+    act(() => {
+      emit("onPaywallError", {
+        errorString: "wrong placement",
+        handlerId: "placement-b",
+      })
+    })
+
+    expect(scopedError).not.toHaveBeenCalled()
+    expect(globalError).toHaveBeenCalledWith("wrong placement")
+
+    act(() => {
+      emit("onPaywallError", {
+        errorString: "matching placement",
+        handlerId: "placement-a",
+      })
+    })
+
+    expect(scopedError).toHaveBeenCalledWith("matching placement")
+    act(() => {
+      renderer!.unmount()
+    })
+  })
+
+  it("does not run the placement feature immediately and runs it on skip", async () => {
+    const registerPlacement = jest.fn().mockResolvedValue(undefined)
+    const feature = jest.fn()
+    let placementApi: ReturnType<typeof usePlacement> | undefined
+
+    useSuperwallStore.setState({ registerPlacement })
+
+    function Harness() {
+      placementApi = usePlacement()
+      return null
+    }
+
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        <SuperwallContext.Provider value={true}>
+          <Harness />
+        </SuperwallContext.Provider>,
+      )
+    })
+
+    await act(async () => {
+      await placementApi!.registerPlacement({
+        placement: "test-placement",
+        feature,
+      })
+    })
+
+    expect(feature).not.toHaveBeenCalled()
+
+    const handlerId = registerPlacement.mock.calls[0][2]
+
+    act(() => {
+      emit("onPaywallSkip", {
+        skippedReason: { type: "NoAudienceMatch" },
+        handlerId,
+      })
+    })
+
+    expect(feature).toHaveBeenCalledTimes(1)
+    act(() => {
+      renderer!.unmount()
+    })
+  })
+
+  it("runs the placement feature only for purchased/restored dismissals", async () => {
+    const registerPlacement = jest.fn().mockResolvedValue(undefined)
+    const feature = jest.fn()
+    let placementApi: ReturnType<typeof usePlacement> | undefined
+
+    useSuperwallStore.setState({ registerPlacement })
+
+    function Harness() {
+      placementApi = usePlacement()
+      return null
+    }
+
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        <SuperwallContext.Provider value={true}>
+          <Harness />
+        </SuperwallContext.Provider>,
+      )
+    })
+
+    await act(async () => {
+      await placementApi!.registerPlacement({
+        placement: "declined-placement",
+        feature,
+      })
+    })
+
+    let handlerId = registerPlacement.mock.calls[0][2]
+
+    act(() => {
+      emit("onPaywallDismiss", {
+        paywallInfoJson: { name: "declined" },
+        result: { type: "declined" },
+        handlerId,
+      })
+    })
+
+    expect(feature).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await placementApi!.registerPlacement({
+        placement: "purchased-placement",
+        feature,
+      })
+    })
+
+    handlerId = registerPlacement.mock.calls[1][2]
+
+    act(() => {
+      emit("onPaywallDismiss", {
+        paywallInfoJson: { name: "purchased" },
+        result: { type: "purchased", productId: "pro" },
+        handlerId,
+      })
+    })
+
+    expect(feature).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await placementApi!.registerPlacement({
+        placement: "errored-placement",
+        feature,
+      })
+    })
+
+    handlerId = registerPlacement.mock.calls[2][2]
+
+    act(() => {
+      emit("onPaywallError", {
+        errorString: "boom",
+        handlerId,
+      })
+    })
+
+    act(() => {
+      emit("onPaywallDismiss", {
+        paywallInfoJson: { name: "post-error" },
+        result: { type: "restored" },
+        handlerId,
+      })
+    })
+
+    expect(feature).toHaveBeenCalledTimes(1)
+    act(() => {
+      renderer!.unmount()
+    })
+  })
+
+  it("stores missing platform API key failures and reports them once", async () => {
+    const onConfigurationError = jest.fn()
+    const configure = jest.fn().mockResolvedValue(undefined)
+
+    useSuperwallStore.setState({ configure })
+
+    let renderer: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <SuperwallProvider apiKeys={{ android: "android-key" }} onConfigurationError={onConfigurationError}>
+          <></>
+        </SuperwallProvider>,
+      )
+
+      await Promise.resolve()
+    })
+
+    expect(configure).not.toHaveBeenCalled()
+    expect(useSuperwallStore.getState().configurationError).toBe(
+      "No API key provided for platform ios",
+    )
+    expect(onConfigurationError).toHaveBeenCalledTimes(1)
+    expect(onConfigurationError.mock.calls[0][0]).toBeInstanceOf(Error)
+    expect(onConfigurationError.mock.calls[0][0].message).toBe(
+      "No API key provided for platform ios",
+    )
+
+    act(() => {
+      renderer!.unmount()
+    })
+  })
+})

--- a/src/usePlacement.ts
+++ b/src/usePlacement.ts
@@ -1,4 +1,4 @@
-import { useCallback, useId, useState } from "react"
+import { useCallback, useId, useRef, useState } from "react"
 
 import type {
   CustomCallback,
@@ -109,20 +109,38 @@ export function usePlacement(callbacks: usePlacementCallbacks = {}) {
   const id = useId()
 
   const [state, setState] = useState<PaywallState>({ status: "idle" })
+  const pendingFeatureRef = useRef<RegisterPlacementArgs["feature"]>(undefined)
+
+  const clearPendingFeature = useCallback(() => {
+    pendingFeatureRef.current = undefined
+  }, [])
+
+  const runPendingFeature = useCallback(() => {
+    const feature = pendingFeatureRef.current
+    pendingFeatureRef.current = undefined
+    feature?.()
+  }, [])
 
   useSuperwallEvents({
     handlerId: id,
     onPaywallDismiss(info, result) {
       setState({ status: "dismissed", result })
+      if (result.type === "purchased" || result.type === "restored") {
+        runPendingFeature()
+      } else {
+        clearPendingFeature()
+      }
 
       callbacks.onDismiss?.(info, result)
     },
     onPaywallSkip(reason) {
       setState({ status: "skipped", reason })
+      runPendingFeature()
       callbacks.onSkip?.(reason)
     },
     onPaywallError(error) {
       setState({ status: "error", error })
+      clearPendingFeature()
       callbacks.onError?.(error)
     },
     onPaywallPresent(info) {
@@ -139,9 +157,13 @@ export function usePlacement(callbacks: usePlacementCallbacks = {}) {
   /* -------------------- Helpers -------------------- */
   const registerPlacement = useCallback(
     async ({ placement, params, feature }: RegisterPlacementArgs) => {
-      await storeRegisterPlacement(placement, params, id)
-      // Execute feature if provided (called when the user is allowed access)
-      feature?.()
+      pendingFeatureRef.current = feature
+      try {
+        await storeRegisterPlacement(placement, params, id)
+      } catch (error) {
+        pendingFeatureRef.current = undefined
+        throw error
+      }
     },
     [storeRegisterPlacement, id],
   )

--- a/src/useSuperwallEvents.ts
+++ b/src/useSuperwallEvents.ts
@@ -233,7 +233,8 @@ export function useSuperwallEvents({
     )
 
     subs.push(
-      SuperwallExpoModule.addListener("onPaywallError", ({ errorString }) => {
+      SuperwallExpoModule.addListener("onPaywallError", ({ errorString, handlerId }) => {
+        if (trackedHandlerId && handlerId !== trackedHandlerId) return
         callbacksRef.current.onPaywallError?.(errorString)
       }),
     )


### PR DESCRIPTION
## Summary
- scope paywall error events by `handlerId` so `usePlacement` instances do not receive each other's errors
- defer `usePlacement` feature callbacks until skip, purchase, or restore outcomes instead of running them immediately
- surface missing platform API keys through `configurationError` state so provider error UI behaves consistently
- align Android entitlements with the shared TS contract and expose optional `all` entitlements
- add a Jest config and regression tests for placement gating, error scoping, and provider configuration failures

## Testing
- `yarn test --runInBand`
- `./node_modules/.bin/tsc --noEmit`
- `yarn build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships four distinct improvements: handler-scoped `onPaywallError` events (matching the scoping already in place for present/dismiss/skip), deferred feature callbacks in `usePlacement` so they only execute on valid paywall outcomes, surfacing missing-platform-API-key errors through the shared `configurationError` Zustand state, and Android/iOS entitlement data parity via the shared `toJson()` extension. The changes fit neatly into the existing event-bus + Zustand architecture.

**Key changes:**
- `useSuperwallEvents.ts` — `onPaywallError` now filters by `handlerId`, consistent with the other three core paywall events.
- `usePlacement.ts` — `feature` is stored in `pendingFeatureRef` and executed only on `skip`, `purchased`, or `restored` outcomes; errors and declines clear it.
- `SuperwallProvider.tsx` — missing API key writes `configurationError` to the store; a separate `useEffect` calls `onConfigurationError` when that state changes. However, since `onConfigurationError` is in the dependency array as a raw prop, any parent re-render that passes a new function reference (no `useCallback`) will re-invoke the callback on every render after the error is set.
- `android/.../SuperwallExpoModule.kt` — `getEntitlements` now uses the shared `toJson()` extension and includes the `all` entitlement set, matching iOS.
- `src/SuperwallExpoModule.types.ts` — `EntitlementsInfo.all` added as optional, maintaining backward compatibility.
- `jest.config.js` + `src/__tests__/sdk.behavior.test.tsx` — new regression tests for the above behaviors; React module resolution is hard-coded to `example/node_modules`, which may break in CI setups that don't install the example project.
- `usePlacement.ts` — the single `pendingFeatureRef` slot is silently overwritten if `registerPlacement` is called a second time before the first placement resolves, potentially running the wrong feature or dropping one entirely.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with caution — the core event-scoping and Android parity changes are correct, but two logic issues in SuperwallProvider and usePlacement should be addressed before shipping to production.
- The error-scoping fix and entitlement parity are solid and well-tested. However, the new onConfigurationError useEffect depends on the prop reference directly, meaning any unstable (non-memoized) callback passed by a parent will be called repeatedly after an error — a regression from the intended "report once" behavior. Additionally, the single pendingFeatureRef slot in usePlacement can silently drop or mis-route a feature callback under concurrent registerPlacement calls. Neither issue is caught by the new tests because both use stable mock references.
- src/SuperwallProvider.tsx (repeated onConfigurationError calls) and src/usePlacement.ts (single-slot pendingFeatureRef overwrite)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/SuperwallProvider.tsx | Stores missing API key errors in Zustand instead of calling onConfigurationError directly; introduces a second useEffect that may repeatedly invoke onConfigurationError whenever the prop reference changes. |
| src/usePlacement.ts | Defers feature callback execution to specific paywall outcomes via pendingFeatureRef; concurrent registerPlacement calls silently overwrite each other's pending feature due to the single-slot ref. |
| src/useSuperwallEvents.ts | Adds handlerId scoping to onPaywallError, making it consistent with the existing scoping already applied to onPaywallPresent, onPaywallDismiss, and onPaywallSkip — clean, correct change. |
| src/__tests__/sdk.behavior.test.tsx | New regression suite covering error scoping, feature deferral, and provider configuration failures; tests use stable mock references so the unstable-onConfigurationError-prop regression is not caught. |
| android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt | Refactors getEntitlements to use the shared toJson() extension and widens the map type to Map<String, Any> to accommodate the added type field, bringing Android to parity with iOS. |
| src/SuperwallExpoModule.types.ts | Adds optional all field to EntitlementsInfo to match the native bridge data now returned on both iOS and Android — well-typed and backward compatible. |
| jest.config.js | New Jest config that spreads expo-module-scripts preset and maps React imports to example/node_modules; the hard-coded example sub-project path may cause test failures in CI environments that haven't installed example dependencies. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant usePlacement
    participant useSuperwallEvents
    participant NativeSDK

    App->>usePlacement: registerPlacement({ placement, feature })
    usePlacement->>usePlacement: pendingFeatureRef.current = feature
    usePlacement->>NativeSDK: storeRegisterPlacement(placement, params, handlerId)

    alt No audience match / already subscribed
        NativeSDK-->>useSuperwallEvents: onPaywallSkip { skippedReason, handlerId }
        useSuperwallEvents->>usePlacement: onPaywallSkip(reason)
        usePlacement->>App: runPendingFeature()
        NativeSDK-->>usePlacement: promise resolves (ref already cleared)
    else Paywall shown, user purchases or restores
        NativeSDK-->>useSuperwallEvents: onPaywallDismiss { result: purchased, handlerId }
        useSuperwallEvents->>usePlacement: onPaywallDismiss(info, result)
        usePlacement->>App: runPendingFeature()
        NativeSDK-->>usePlacement: promise resolves (ref already cleared)
    else Paywall shown, user declines
        NativeSDK-->>useSuperwallEvents: onPaywallDismiss { result: declined, handlerId }
        useSuperwallEvents->>usePlacement: onPaywallDismiss(info, result)
        usePlacement->>usePlacement: clearPendingFeature()
    else Error occurs
        NativeSDK-->>useSuperwallEvents: onPaywallError { errorString, handlerId }
        useSuperwallEvents->>usePlacement: onPaywallError(error)
        usePlacement->>usePlacement: clearPendingFeature()
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/SuperwallProvider.tsx`, line 128-132 ([link](https://github.com/superwall/expo-superwall/blob/ba39bf02e230ceb6bd562396b0014a693846ad38/src/SuperwallProvider.tsx#L128-L132)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`onConfigurationError` called on every parent re-render**

   This `useEffect` lists `onConfigurationError` as a dependency. Because `onConfigurationError` is a plain prop (not guaranteed to be stable), a parent component that doesn't wrap the callback in `useCallback` will supply a **new function reference on every render**. Once `configurationError` is set, any subsequent parent re-render causes the effect to re-fire and invoke `onConfigurationError` again — potentially triggering analytics events, UI state updates, or error-reporting calls many times rather than once.

   The test passes because `jest.fn()` is created once and never changes reference, so it never exercises the unstable-reference path.

   A safe fix is to use a ref to guard against duplicate calls:

   ```
   // Notify callback when configuration error changes
   const notifiedErrorRef = useRef<string | null>(null)
   useEffect(() => {
     if (configurationError && onConfigurationError && notifiedErrorRef.current !== configurationError) {
       notifiedErrorRef.current = configurationError
       onConfigurationError(new Error(configurationError))
     }
   }, [configurationError, onConfigurationError])
   ```

   Alternatively, remove `onConfigurationError` from the dependency array (with an eslint-disable comment) and capture it in a ref, similar to how `callbacksRef` is used in `useSuperwallEvents`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/SuperwallProvider.tsx
   Line: 128-132

   Comment:
   **`onConfigurationError` called on every parent re-render**

   This `useEffect` lists `onConfigurationError` as a dependency. Because `onConfigurationError` is a plain prop (not guaranteed to be stable), a parent component that doesn't wrap the callback in `useCallback` will supply a **new function reference on every render**. Once `configurationError` is set, any subsequent parent re-render causes the effect to re-fire and invoke `onConfigurationError` again — potentially triggering analytics events, UI state updates, or error-reporting calls many times rather than once.

   The test passes because `jest.fn()` is created once and never changes reference, so it never exercises the unstable-reference path.

   A safe fix is to use a ref to guard against duplicate calls:

   ```
   // Notify callback when configuration error changes
   const notifiedErrorRef = useRef<string | null>(null)
   useEffect(() => {
     if (configurationError && onConfigurationError && notifiedErrorRef.current !== configurationError) {
       notifiedErrorRef.current = configurationError
       onConfigurationError(new Error(configurationError))
     }
   }, [configurationError, onConfigurationError])
   ```

   Alternatively, remove `onConfigurationError` from the dependency array (with an eslint-disable comment) and capture it in a ref, similar to how `callbacksRef` is used in `useSuperwallEvents`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/SuperwallProvider.tsx
Line: 128-132

Comment:
**`onConfigurationError` called on every parent re-render**

This `useEffect` lists `onConfigurationError` as a dependency. Because `onConfigurationError` is a plain prop (not guaranteed to be stable), a parent component that doesn't wrap the callback in `useCallback` will supply a **new function reference on every render**. Once `configurationError` is set, any subsequent parent re-render causes the effect to re-fire and invoke `onConfigurationError` again — potentially triggering analytics events, UI state updates, or error-reporting calls many times rather than once.

The test passes because `jest.fn()` is created once and never changes reference, so it never exercises the unstable-reference path.

A safe fix is to use a ref to guard against duplicate calls:

```
// Notify callback when configuration error changes
const notifiedErrorRef = useRef<string | null>(null)
useEffect(() => {
  if (configurationError && onConfigurationError && notifiedErrorRef.current !== configurationError) {
    notifiedErrorRef.current = configurationError
    onConfigurationError(new Error(configurationError))
  }
}, [configurationError, onConfigurationError])
```

Alternatively, remove `onConfigurationError` from the dependency array (with an eslint-disable comment) and capture it in a ref, similar to how `callbacksRef` is used in `useSuperwallEvents`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/usePlacement.ts
Line: 158-168

Comment:
**Concurrent `registerPlacement` calls silently drop the first pending feature**

`pendingFeatureRef` holds a single slot. If `registerPlacement` is called a second time before the first placement emits a skip/dismiss event (e.g., the user re-taps a button while a paywall is loading), the second call overwrites `pendingFeatureRef.current`. The first call's feature callback is silently discarded.

Worse, when the skip/dismiss event for the first placement eventually fires (matched by `handlerId`), it will execute the **second** feature instead of the first.

Since `id` (from `useId()`) is stable per hook instance and `handlerId` is scoped, each active `registerPlacement` call should be tracked separately. Consider keying pending features by a per-call ID, or preventing a new `registerPlacement` call while one is already in flight and documenting that restriction explicitly.

```
// Example: prevent overlapping calls
const registerPlacement = useCallback(
  async ({ placement, params, feature }: RegisterPlacementArgs) => {
    if (pendingFeatureRef.current !== undefined) {
      console.warn("[Superwall] registerPlacement called while a previous call is in-flight; ignoring.")
      return
    }
    pendingFeatureRef.current = feature
    try {
      await storeRegisterPlacement(placement, params, id)
    } catch (error) {
      pendingFeatureRef.current = undefined
      throw error
    }
  },
  [storeRegisterPlacement, id],
)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: jest.config.js
Line: 5-7

Comment:
**React module resolution hard-codes the `example` sub-project's `node_modules`**

Resolving `react` from `<rootDir>/example/node_modules/react` means tests will silently fail (with a confusing "Cannot find module" error) on any machine that hasn't run `yarn install` inside the `example/` directory — common in CI environments that only install root dependencies, or when contributors run `yarn install` without `--workspaces`.

Consider aliasing to the root `node_modules` instead:

```suggestion
    "^react$": "<rootDir>/node_modules/react",
    "^react/jsx-runtime$": "<rootDir>/node_modules/react/jsx-runtime",
    "^react/jsx-dev-runtime$": "<rootDir>/node_modules/react/jsx-dev-runtime",
```

If `react` must come from the example sub-project for version-compatibility reasons, document that requirement in `CLAUDE.md` or a comment so CI setup is clear.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/__tests__/sdk.behavior.test.tsx
Line: 274-304

Comment:
**Test only covers stable callback reference — misses the repeated-call regression**

The `onConfigurationError` used here is a stable `jest.fn()` reference, so the `useEffect([configurationError, onConfigurationError])` in `SuperwallProvider` never re-fires due to reference churn. The assertion `expect(onConfigurationError).toHaveBeenCalledTimes(1)` would still pass even if the callback fires on every parent render in production.

Consider adding a companion test that wraps `SuperwallProvider` inside a stateful parent that re-renders after the error is set, then asserts `onConfigurationError` is still called exactly once. This would catch the unstable-reference regression described in the inline comment on `SuperwallProvider.tsx:128`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["Fix SDK event scopin..."](https://github.com/superwall/expo-superwall/commit/ba39bf02e230ceb6bd562396b0014a693846ad38)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->