### PR TITLE
Fix presentation result type and delegate overriding

### DIFF
--- a/.changeset/four-mirrors-pump.md
+++ b/.changeset/four-mirrors-pump.md
@@ -1,0 +1,5 @@
+---
+"expo-superwall": patch
+---
+
+Replace any in getPresentation result, improve chaining on delegate

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ The hook returns an object representing the Superwall store. If a `selector` fun
         -   `IdentifyOptions`:
             -   `restorePaywallAssignments?: boolean`: If true, restores paywall assignments from a previous session.
     -   `registerPlacement: (placement: string, params?: Record<string, any>, handlerId?: string | null) => Promise<void>`: Registers a placement. This may or may not present a paywall depending on campaign rules. `handlerId` is used internally by `usePlacement` to associate events.
-    -   `getPresentationResult: (placement: string, params?: Record<string, any>) => Promise<any>`: Gets the presentation result for a given placement.
+    -   `getPresentationResult: (placement: string, params?: Record<string, any>) => Promise<PresentationResult>`: Gets the presentation result for a given placement.
     -   `dismiss: () => Promise<void>`: Dismisses any currently presented paywall.
     -   `preloadAllPaywalls: () => Promise<void>`: Preloads all paywalls.
     -   `preloadPaywalls: (placements: string[]) => Promise<void>`: Preloads paywalls for the specified placement IDs.

--- a/src/SuperwallExpoModule.ts
+++ b/src/SuperwallExpoModule.ts
@@ -1,4 +1,5 @@
 import { NativeModule, requireNativeModule } from "expo"
+import type { PresentationResult } from "./compat/lib/PresentationResult"
 import type {
   EntitlementsInfo,
   IntegrationAttributes,
@@ -49,7 +50,11 @@ declare class SuperwallExpoModule extends NativeModule<SuperwallExpoModuleEvents
   ): void
   didRestore(result: Record<string, any>): void
   didHandleBackPressed(shouldConsume: boolean): void
-  didHandleCustomCallback(callbackId: string, status: string, data?: Record<string, any>): Promise<void>
+  didHandleCustomCallback(
+    callbackId: string,
+    status: string,
+    data?: Record<string, any>,
+  ): Promise<void>
 
   dismiss(): Promise<void>
   confirmAllAssignments(): Promise<any[]>
@@ -57,7 +62,7 @@ declare class SuperwallExpoModule extends NativeModule<SuperwallExpoModuleEvents
   getPresentationResult(
     placement: string,
     params?: Map<string, any> | Record<string, any>,
-  ): Promise<any>
+  ): Promise<PresentationResult>
 
   getDeviceAttributes(): Promise<Record<string, any>>
 

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -18,6 +18,15 @@ import { SuperwallEventInfo } from "./lib/SuperwallEventInfo"
 import { type PartialSuperwallOptions, SuperwallOptions } from "./lib/SuperwallOptions"
 
 export { PaywallResult } from "./lib/PaywallResult"
+export {
+  PresentationResult,
+  PresentationResultHoldout,
+  PresentationResultNoAudienceMatch,
+  PresentationResultPaywall,
+  PresentationResultPaywallNotAvailable,
+  PresentationResultPlacementNotFound,
+  PresentationResultUserIsSubscribed,
+} from "./lib/PresentationResult"
 
 import { EventEmitter } from "expo"
 import { version } from "../../package.json"
@@ -66,7 +75,11 @@ export { StoreTransaction } from "./lib/StoreTransaction"
 export { SubscriptionStatus } from "./lib/SubscriptionStatus"
 export { SuperwallDelegate } from "./lib/SuperwallDelegate"
 export { EventType, SuperwallEventInfo } from "./lib/SuperwallEventInfo"
-export { type PartialSuperwallOptions, SuperwallOptions, TestModeBehavior } from "./lib/SuperwallOptions"
+export {
+  type PartialSuperwallOptions,
+  SuperwallOptions,
+  TestModeBehavior,
+} from "./lib/SuperwallOptions"
 export { Survey } from "./lib/Survey"
 export { TriggerResult } from "./lib/TriggerResult"
 
@@ -208,7 +221,9 @@ export default class Superwall {
         return
       }
 
-      Promise.resolve(handler.onCustomCallbackHandler({ name: data.name, variables: data.variables })).then(
+      Promise.resolve(
+        handler.onCustomCallbackHandler({ name: data.name, variables: data.variables }),
+      ).then(
         (result) => {
           SuperwallExpoModule.didHandleCustomCallback(data.callbackId, result.status, result.data)
         },

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -235,41 +235,41 @@ export default class Superwall {
 
     // MARK: - SuperwallDelegate Listeners
     SuperwallExpoModule.addListener("subscriptionStatusDidChange", async (data) => {
-      Superwall.delegate?.subscriptionStatusDidChange(data.from, data.to)
+      Superwall.delegate?.subscriptionStatusDidChange?.(data.from, data.to)
     })
 
     SuperwallExpoModule.addListener("handleSuperwallEvent", async (data) => {
       const eventInfo = SuperwallEventInfo.fromJson(data.eventInfo)
-      Superwall.delegate?.handleSuperwallEvent(eventInfo)
+      Superwall.delegate?.handleSuperwallEvent?.(eventInfo)
     })
 
     SuperwallExpoModule.addListener("handleCustomPaywallAction", async (data) => {
       const name = data.name
-      Superwall.delegate?.handleCustomPaywallAction(name)
+      Superwall.delegate?.handleCustomPaywallAction?.(name)
     })
 
     SuperwallExpoModule.addListener("willDismissPaywall", async (data) => {
       const info = PaywallInfo.fromJson(data.info)
-      Superwall.delegate?.willDismissPaywall(info)
+      Superwall.delegate?.willDismissPaywall?.(info)
     })
 
     SuperwallExpoModule.addListener("willPresentPaywall", async (data) => {
       const info = PaywallInfo.fromJson(data.info)
-      Superwall.delegate?.willPresentPaywall(info)
+      Superwall.delegate?.willPresentPaywall?.(info)
     })
 
     SuperwallExpoModule.addListener("didDismissPaywall", async (data) => {
       const info = PaywallInfo.fromJson(data.info)
-      Superwall.delegate?.didDismissPaywall(info)
+      Superwall.delegate?.didDismissPaywall?.(info)
     })
 
     SuperwallExpoModule.addListener("didPresentPaywall", async (data) => {
       const info = PaywallInfo.fromJson(data.info)
-      Superwall.delegate?.didPresentPaywall(info)
+      Superwall.delegate?.didPresentPaywall?.(info)
     })
 
     SuperwallExpoModule.addListener("handleLog", async (data) => {
-      Superwall.delegate?.handleLog(
+      Superwall.delegate?.handleLog?.(
         data.level,
         data.scope,
         data.message || undefined,
@@ -280,21 +280,21 @@ export default class Superwall {
 
     SuperwallExpoModule.addListener("paywallWillOpenDeepLink", async (data) => {
       const url = new URL(data.url)
-      Superwall.delegate?.paywallWillOpenDeepLink(url)
+      Superwall.delegate?.paywallWillOpenDeepLink?.(url)
     })
 
     SuperwallExpoModule.addListener("paywallWillOpenURL", async (data) => {
       const url = new URL(data.url)
-      Superwall.delegate?.paywallWillOpenURL(url)
+      Superwall.delegate?.paywallWillOpenURL?.(url)
     })
 
     SuperwallExpoModule.addListener("willRedeemLink", async () => {
-      Superwall.delegate?.willRedeemLink()
+      Superwall.delegate?.willRedeemLink?.()
     })
 
     SuperwallExpoModule.addListener("didRedeemLink", async (data) => {
       const result = RedemptionResults.fromJson(data)
-      Superwall.delegate?.didRedeemLink(result)
+      Superwall.delegate?.didRedeemLink?.(result)
     })
 
     SuperwallExpoModule.addListener("subscriptionStatusDidChange", async (data) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ export {
   PresentationResultUserIsSubscribed,
 } from "./compat/lib/PresentationResult"
 export * from "./components"
-export * from "./components"
 export { default as SuperwallExpoModule } from "./SuperwallExpoModule"
 export type * from "./SuperwallExpoModule.types"
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
 export * from "./CustomPurchaseControllerProvider"
+export {
+  PresentationResult,
+  PresentationResultHoldout,
+  PresentationResultNoAudienceMatch,
+  PresentationResultPaywall,
+  PresentationResultPaywallNotAvailable,
+  PresentationResultPlacementNotFound,
+  PresentationResultUserIsSubscribed,
+} from "./compat/lib/PresentationResult"
 export * from "./components"
 export * from "./components"
-
 export { default as SuperwallExpoModule } from "./SuperwallExpoModule"
 export type * from "./SuperwallExpoModule.types"
 export type {

--- a/src/useSuperwall.ts
+++ b/src/useSuperwall.ts
@@ -2,6 +2,7 @@ import { createContext, useContext } from "react"
 import { create } from "zustand"
 import { useShallow } from "zustand/shallow"
 import pkg from "../package.json"
+import type { PresentationResult } from "./compat/lib/PresentationResult"
 import SuperwallExpoModule from "./SuperwallExpoModule"
 import type {
   EntitlementsInfo,
@@ -126,7 +127,10 @@ export interface SuperwallStore {
    * @param params - Optional parameters for the placement.
    * @returns A promise that resolves with the presentation result.
    */
-  getPresentationResult: (placement: string, params?: Record<string, any>) => Promise<any>
+  getPresentationResult: (
+    placement: string,
+    params?: Record<string, any>,
+  ) => Promise<PresentationResult>
   /**
    * Dismisses any currently presented Superwall paywall.
    * @returns A promise that resolves when the dismissal is complete.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes several minor quality improvements: it adds proper `PresentationResult` return types to `getPresentationResult` (replacing `Promise<any>`), exports `PresentationResult` and its subclasses from both the hooks SDK and the compat SDK, and adds optional chaining (`?.`) to all delegate method calls to prevent crashes when a partial delegate implementation is used.

- `src/index.ts` retains a duplicate `export * from \"./components\"` (lines 11–12) that this PR touched but didn't remove.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are minor style issues.

The changes are straightforward type improvements and defensive optional chaining. The only flagged issue is a pre-existing duplicate barrel export that is harmless at runtime.

src/index.ts has a duplicate `export * from "./components"` worth cleaning up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/index.ts | Adds PresentationResult exports from compat lib; retains a pre-existing duplicate `export * from "./components"` that should be cleaned up. |
| src/compat/index.ts | Exports PresentationResult subclasses and adds optional chaining to all delegate method calls for safer partial implementations; formatting improvements only. |
| src/SuperwallExpoModule.ts | Return type of `getPresentationResult` tightened from `Promise<any>` to `Promise<PresentationResult>`; formatting fix for `didHandleCustomCallback`. |
| src/useSuperwall.ts | Store interface updated to return `Promise<PresentationResult>` from `getPresentationResult` for improved type safety. |
| README.md | Documentation updated to reflect the new `PresentationResult` return type for `getPresentationResult`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SuperwallDelegate event fires] --> B{delegate set?}
    B -- No --> C[Skip via ?. on delegate]
    B -- Yes --> D{method implemented?}
    D -- No --> E[Skip via ?. on method call]
    D -- Yes --> F[Call delegate method]

    G[getPresentationResult] --> H[Native module call]
    H --> I[Promise&lt;PresentationResult&gt;]
    I --> J[PresentationResultPaywall\nPresentationResultHoldout\nPresentationResultNoAudienceMatch\nPresentationResultUserIsSubscribed\nPresentationResultPlacementNotFound\nPresentationResultPaywallNotAvailable]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/index.ts
Line: 11-12

Comment:
**Duplicate barrel export**

`export * from "./components"` appears twice in a row. While this won't cause a TypeScript error (re-exporting the same namespace is a no-op), it's dead code and can cause confusion. Since this file was touched in this PR, it's a good opportunity to remove the duplicate.

```suggestion
export * from "./components"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changeset): Replace any in getPrese..."](https://github.com/superwall/expo-superwall/commit/9d23138d8522e9f4d4561574bc3b7b4a35315801) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28020941)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->