### PR TITLE
Bump Android, add consume method

### DIFF
--- a/.changeset/busy-bananas-film.md
+++ b/.changeset/busy-bananas-film.md
@@ -1,0 +1,5 @@
+---
+"expo-superwall": patch
+---
+
+Add android 'consume' method

--- a/.changeset/hot-toys-stare.md
+++ b/.changeset/hot-toys-stare.md
@@ -1,0 +1,5 @@
+---
+"expo-superwall": patch
+---
+
+Bump Android version

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-  implementation "com.superwall.sdk:superwall-android:2.7.8"
+  implementation "com.superwall.sdk:superwall-android:2.7.11"
   implementation 'com.android.billingclient:billing:8.0.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.2'
 }

--- a/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
@@ -482,5 +482,15 @@ class SuperwallExpoModule : Module() {
       val attributes = Superwall.instance.integrationAttributes
       promise.resolve(attributes)
     }
+
+    AsyncFunction("consume") { purchaseToken: String, promise: Promise ->
+      ioScope.launch {
+        Superwall.instance.consume(purchaseToken).fold({ token ->
+          scope.launch { promise.resolve(token) }
+        }, { error ->
+          scope.launch { promise.reject(CodedException(error)) }
+        })
+      }
+    }
   }
 }

--- a/ios/SuperwallExpoModule.swift
+++ b/ios/SuperwallExpoModule.swift
@@ -397,5 +397,9 @@ public class SuperwallExpoModule: Module {
       let attributes = Superwall.shared.integrationAttributes
       promise.resolve(attributes)
     }
+
+    AsyncFunction("consume") { (_: String, promise: Promise) in
+      promise.resolve(nil)
+    }
   }
 }

--- a/src/SuperwallExpoModule.ts
+++ b/src/SuperwallExpoModule.ts
@@ -73,6 +73,8 @@ declare class SuperwallExpoModule extends NativeModule<SuperwallExpoModuleEvents
 
   setIntegrationAttributes(attributes: IntegrationAttributes): Promise<void>
   getIntegrationAttributes(): Promise<Record<string, string>>
+
+  consume(purchaseToken: string): Promise<string>
 }
 
 export default requireNativeModule<SuperwallExpoModule>("SuperwallExpo")

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -753,4 +753,15 @@ export default class Superwall {
     await this.awaitConfig()
     return SuperwallExpoModule.getIntegrationAttributes()
   }
+
+  /**
+   * Consumes a Google Play purchase token so the item can be purchased again.
+   * Android-only; rejects on iOS.
+   * @param purchaseToken - The Google Play purchase token to consume.
+   * @returns The consumed purchase token on success.
+   */
+  async consume(purchaseToken: string): Promise<string> {
+    await this.awaitConfig()
+    return SuperwallExpoModule.consume(purchaseToken)
+  }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the Superwall Android SDK to `2.7.11`, adds an explicit `com.android.billingclient:billing:8.0.0` dependency, and exposes a new `consume(purchaseToken)` method on both the native bridge and the compat TypeScript API for consuming Google Play purchase tokens.

- The iOS stub at `ios/SuperwallExpoModule.swift:401-403` calls `promise.resolve(nil)` instead of rejecting. The compat JSDoc states the method "rejects on iOS", but the implementation silently resolves `null`, breaking the documented contract and the `Promise<string>` return type for any iOS caller.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the iOS stub to reject instead of silently resolving nil.

One P1 finding: the iOS consume stub resolves nil rather than rejecting, contradicting the documented behavior and the TypeScript return type. The Android implementation and TS declarations are correct. Fixing the stub is a one-liner.

ios/SuperwallExpoModule.swift — the consume stub needs to reject instead of resolve.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ios/SuperwallExpoModule.swift | Adds stub consume that silently resolves nil instead of rejecting, contradicting the documented rejects on iOS contract and the TypeScript return type of Promise<string>. |
| android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt | Adds consume AsyncFunction that delegates to Superwall.instance.consume(purchaseToken), properly folding Result to resolve/reject on the main scope. |
| android/build.gradle | Bumps Superwall Android SDK to 2.7.11 and adds explicit com.android.billingclient:billing:8.0.0 dependency. |
| src/compat/index.ts | Adds consume method with correct JSDoc noting Android-only behavior; however, iOS will silently return null rather than rejecting as documented. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TS as TypeScript (compat)
    participant NM as Native Module
    participant SW as Superwall SDK

    Note over TS,SW: consume() flow - Android
    TS->>NM: consume(purchaseToken)
    NM->>SW: Superwall.instance.consume(purchaseToken)
    SW-->>NM: Result<String> (success/failure)
    alt success
        NM-->>TS: resolve(token)
    else failure
        NM-->>TS: reject(CodedException)
    end

    Note over TS,SW: consume() flow - iOS (stub)
    TS->>NM: consume(purchaseToken)
    NM-->>TS: resolve(nil) ← should reject
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: ios/SuperwallExpoModule.swift
Line: 401-403

Comment:
**iOS stub resolves instead of rejecting**

The JSDoc on the compat `consume` method explicitly states "Android-only; rejects on iOS", but the stub resolves with `nil`. This means iOS callers wrapping `consume` in a `try/catch` will never see an error, and the returned value will be `null` — violating the declared `Promise<string>` return type. The stub should reject with an unsupported-platform error.

```suggestion
    AsyncFunction("consume") { (_: String, promise: Promise) in
      promise.reject("ERR_UNSUPPORTED_PLATFORM", "consume is only supported on Android")
    }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changeset): Bump Android version"](https://github.com/superwall/expo-superwall/commit/2204ee800513cf2f0dad380f7b80dcedc4195bbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28219796)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->