### PR TITLE
Bump iOS to 4.15.1 + Android to 2.7.12, expose new APIs

### DIFF
--- a/.changeset/bump-ios-4-15-1.md
+++ b/.changeset/bump-ios-4-15-1.md
@@ -1,0 +1,16 @@
+---
+"expo-superwall": minor
+---
+
+Bump native SDKs and expose new APIs.
+
+**iOS — SuperwallKit 4.14.1 → 4.15.1**
+
+- New `paywallPageView` event for multi-page paywall navigation tracking (with `PageViewData` payload).
+- `PaywallInfo.presentationId` is now bridged so events within a single presentation can be correlated.
+- Custom store products are fully bridged: `Product` now carries `store` (`APP_STORE` | `STRIPE` | `PADDLE` | `PLAY_STORE` | `SUPERWALL` | `CUSTOM` | `OTHER`) plus per-store identifier objects (`appStoreProduct`, `stripeProduct`, `paddleProduct`, `customProduct`). `onPurchase` also receives `store` so JS can route `CUSTOM` products to its own purchase logic instead of StoreKit.
+
+**Android — Superwall-Android 2.7.11 → 2.7.12**
+
+- Bridges the new `customerInfo` field on `PaywallInfo` (subscriptions, non-subscriptions, entitlements, userId).
+- Picks up new intro-offer eligibility logic for Stripe/Paddle products and bottom-sheet dismiss fix on newer Samsung devices.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-  implementation "com.superwall.sdk:superwall-android:2.7.11"
+  implementation "com.superwall.sdk:superwall-android:2.7.12"
   implementation 'com.android.billingclient:billing:8.0.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.2'
 }

--- a/android/src/main/java/expo/modules/superwallexpo/json/CustomerInfo.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/json/CustomerInfo.kt
@@ -1,0 +1,50 @@
+package expo.modules.superwallexpo.json
+
+import com.superwall.sdk.models.customer.CustomerInfo
+import com.superwall.sdk.models.customer.NonSubscriptionTransaction
+import com.superwall.sdk.models.customer.SubscriptionTransaction
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Date
+
+private val dateFormatter: DateTimeFormatter = DateTimeFormatter.ISO_INSTANT
+
+private fun Date.toIsoString(): String =
+  this.toInstant().atZone(ZoneId.systemDefault()).format(dateFormatter)
+
+fun CustomerInfo.toJson(): Map<String, Any?> {
+  val map = mutableMapOf<String, Any?>()
+  map["userId"] = this.userId
+  map["subscriptions"] = this.subscriptions.map { it.toJson() }
+  map["nonSubscriptions"] = this.nonSubscriptions.map { it.toJson() }
+  map["entitlements"] = this.entitlements.map { it.toJson() }
+  return map
+}
+
+fun SubscriptionTransaction.toJson(): Map<String, Any?> {
+  val map = mutableMapOf<String, Any?>()
+  map["transactionId"] = this.transactionId
+  map["productId"] = this.productId
+  map["purchaseDate"] = this.purchaseDate.toIsoString()
+  map["willRenew"] = this.willRenew
+  map["isRevoked"] = this.isRevoked
+  map["isInGracePeriod"] = this.isInGracePeriod
+  map["isInBillingRetryPeriod"] = this.isInBillingRetryPeriod
+  map["isActive"] = this.isActive
+  map["expirationDate"] = this.expirationDate?.toIsoString()
+  map["store"] = this.store.name
+  this.offerType?.let { map["offerType"] = it.name.lowercase() }
+  this.subscriptionGroupId?.let { map["subscriptionGroupId"] = it }
+  return map
+}
+
+fun NonSubscriptionTransaction.toJson(): Map<String, Any?> {
+  val map = mutableMapOf<String, Any?>()
+  map["transactionId"] = this.transactionId
+  map["productId"] = this.productId
+  map["purchaseDate"] = this.purchaseDate.toIsoString()
+  map["isConsumable"] = this.isConsumable
+  map["isRevoked"] = this.isRevoked
+  map["store"] = this.store.name
+  return map
+}

--- a/android/src/main/java/expo/modules/superwallexpo/json/CustomerInfo.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/json/CustomerInfo.kt
@@ -3,9 +3,22 @@ package expo.modules.superwallexpo.json
 import com.superwall.sdk.models.customer.CustomerInfo
 import com.superwall.sdk.models.customer.NonSubscriptionTransaction
 import com.superwall.sdk.models.customer.SubscriptionTransaction
+import com.superwall.sdk.store.abstractions.product.receipt.LatestPeriodType
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Date
+
+// Mirrors the @SerialName values on `LatestPeriodType`. Exhaustive `when` so a new
+// SDK case is a compile error rather than a silently-incorrect string.
+private fun LatestPeriodType.toJsonString(): String =
+  when (this) {
+    LatestPeriodType.TRIAL -> "trial"
+    LatestPeriodType.CODE -> "code"
+    LatestPeriodType.SUBSCRIPTION -> "subscription"
+    LatestPeriodType.PROMOTIONAL -> "promotional"
+    LatestPeriodType.WINBACK -> "winback"
+    LatestPeriodType.REVOKED -> "revoked"
+  }
 
 private val dateFormatter: DateTimeFormatter = DateTimeFormatter.ISO_INSTANT
 
@@ -33,7 +46,7 @@ fun SubscriptionTransaction.toJson(): Map<String, Any?> {
   map["isActive"] = this.isActive
   map["expirationDate"] = this.expirationDate?.toIsoString()
   map["store"] = this.store.name
-  this.offerType?.let { map["offerType"] = it.name.lowercase() }
+  this.offerType?.let { map["offerType"] = it.toJsonString() }
   this.subscriptionGroupId?.let { map["subscriptionGroupId"] = it }
   return map
 }

--- a/android/src/main/java/expo/modules/superwallexpo/json/PaywallInfo.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/json/PaywallInfo.kt
@@ -92,5 +92,7 @@ fun PaywallInfo.toJson(): Map<String, Any?> {
 
   map["state"] = this.state
 
+  map["customerInfo"] = this.customerInfo.toJson()
+
   return map
 }

--- a/ios/Bridges/PurchaseControllerBridge.swift
+++ b/ios/Bridges/PurchaseControllerBridge.swift
@@ -17,6 +17,16 @@ final class PurchaseControllerBridge: PurchaseController {
 
         if let store = await Self.storeForProductIdentifier(product.productIdentifier) {
             payload["store"] = store
+        } else {
+            // No matching product on the latest paywall — the paywall may have been
+            // dismissed or replaced before this callback fired. JS will receive
+            // `onPurchase` without a `store` field and must default to StoreKit.
+            // CUSTOM products in this state will fail; surface it loudly during
+            // integration so it can be caught.
+            print("[SuperwallExpo] onPurchase: could not resolve store for product " +
+                  "\"\(product.productIdentifier)\" against latestPaywallInfo. " +
+                  "If this is a CUSTOM product, the JS purchase handler will not " +
+                  "receive `store: \"CUSTOM\"` and may incorrectly fall through to StoreKit.")
         }
 
         SuperwallExpoModule.emitEvent("onPurchase", payload)

--- a/ios/Bridges/PurchaseControllerBridge.swift
+++ b/ios/Bridges/PurchaseControllerBridge.swift
@@ -10,16 +10,30 @@ final class PurchaseControllerBridge: PurchaseController {
     private init() {}
 
     func purchase(product: StoreProduct) async -> PurchaseResult {
-        SuperwallExpoModule.emitEvent(
-            "onPurchase",
-            ["productId": product.productIdentifier, "platform": "ios"]
-        )
+        var payload: [String: Any] = [
+            "productId": product.productIdentifier,
+            "platform": "ios"
+        ]
+
+        if let store = await Self.storeForProductIdentifier(product.productIdentifier) {
+            payload["store"] = store
+        }
+
+        SuperwallExpoModule.emitEvent("onPurchase", payload)
         return await withCheckedContinuation { continuation in
             self.purchaseCompletion = { [weak self] result in
                 continuation.resume(returning: result)
                 self?.purchaseCompletion = nil
             }
         }
+    }
+
+    /// Looks up the product's store from the most recently presented paywall so JS can route
+    /// custom products to its own purchase logic instead of StoreKit.
+    @MainActor
+    private static func storeForProductIdentifier(_ productIdentifier: String) -> String? {
+        let product = Superwall.shared.latestPaywallInfo?.products.first { $0.id == productIdentifier }
+        return product?.objcAdapter.store.toJson()
     }
 
     func restorePurchases() async -> RestorationResult {

--- a/ios/Json/CustomStoreProduct+Json.swift
+++ b/ios/Json/CustomStoreProduct+Json.swift
@@ -1,0 +1,9 @@
+import SuperwallKit
+
+extension CustomStoreProduct {
+  func toJson() -> [String: Any] {
+    return [
+      "id": id
+    ]
+  }
+}

--- a/ios/Json/PaddleProduct+Json.swift
+++ b/ios/Json/PaddleProduct+Json.swift
@@ -1,0 +1,9 @@
+import SuperwallKit
+
+extension PaddleProduct {
+  func toJson() -> [String: Any] {
+    return [
+      "id": id
+    ]
+  }
+}

--- a/ios/Json/PageViewData+Json.swift
+++ b/ios/Json/PageViewData+Json.swift
@@ -1,0 +1,25 @@
+import SuperwallKit
+
+extension PageViewData {
+  func toJson() -> [String: Any] {
+    var map: [String: Any] = [
+      "pageNodeId": self.pageNodeId,
+      "flowPosition": self.flowPosition,
+      "pageName": self.pageName,
+      "navigationNodeId": self.navigationNodeId,
+      "navigationType": self.navigationType
+    ]
+
+    if let previousPageNodeId = self.previousPageNodeId {
+      map["previousPageNodeId"] = previousPageNodeId
+    }
+    if let previousFlowPosition = self.previousFlowPosition {
+      map["previousFlowPosition"] = previousFlowPosition
+    }
+    if let timeOnPreviousPageMs = self.timeOnPreviousPageMs {
+      map["timeOnPreviousPageMs"] = timeOnPreviousPageMs
+    }
+
+    return map
+  }
+}

--- a/ios/Json/PaywallInfo+Json.swift
+++ b/ios/Json/PaywallInfo+Json.swift
@@ -14,21 +14,14 @@ extension PaywallInfo {
     map["identifier"] = self.identifier
     map["name"] = self.name
     map["url"] = self.url.absoluteString
+    if let presentationId = self.presentationId {
+      map["presentationId"] = presentationId
+    }
     if let experiment = self.experiment {
       map["experiment"] = experiment.toJson()
     }
 
-    let products = products.map({ product in
-      var dictionary: [String: Any] = [
-        "id": product.id,
-        "entitlements": product.entitlements.map { $0.toJson() },
-      ]
-      if let name = product.name {
-        dictionary["name"] = name
-      }
-      return dictionary
-    })
-    map["products"] = products
+    map["products"] = products.map { $0.toJson() }
 
     let productIdsArray = self.productIds
     map["productIds"] = productIdsArray

--- a/ios/Json/Product+Json.swift
+++ b/ios/Json/Product+Json.swift
@@ -1,0 +1,28 @@
+import SuperwallKit
+
+extension Product {
+  func toJson() -> [String: Any] {
+    var map: [String: Any] = [
+      "id": id,
+      "entitlements": entitlements.map { $0.toJson() },
+      "store": objcAdapter.store.toJson()
+    ]
+
+    if let name = name {
+      map["name"] = name
+    }
+
+    switch type {
+    case .appStore(let appStoreProduct):
+      map["appStoreProduct"] = appStoreProduct.toJson()
+    case .stripe(let stripeProduct):
+      map["stripeProduct"] = stripeProduct.toJson()
+    case .paddle(let paddleProduct):
+      map["paddleProduct"] = paddleProduct.toJson()
+    case .custom(let customProduct):
+      map["customProduct"] = customProduct.toJson()
+    }
+
+    return map
+  }
+}

--- a/ios/Json/ProductStore+Json.swift
+++ b/ios/Json/ProductStore+Json.swift
@@ -13,7 +13,11 @@ extension ProductStore {
       return "SUPERWALL"
     case .playStore:
       return "PLAY_STORE"
+    case .custom:
+      return "CUSTOM"
     case .other:
+      return "OTHER"
+    @unknown default:
       return "OTHER"
     }
   }

--- a/ios/Json/StripeProduct+Json.swift
+++ b/ios/Json/StripeProduct+Json.swift
@@ -1,0 +1,13 @@
+import SuperwallKit
+
+extension StripeProduct {
+  func toJson() -> [String: Any] {
+    var map: [String: Any] = [
+      "id": id
+    ]
+    if let trialDays = trialDays {
+      map["trialDays"] = trialDays
+    }
+    return map
+  }
+}

--- a/ios/Json/SuperwallPlacementInfo+Json.swift
+++ b/ios/Json/SuperwallPlacementInfo+Json.swift
@@ -263,6 +263,12 @@ extension SuperwallEvent {
       return ["event": "stripeCheckoutComplete", "paywallInfo": paywallInfo.toJson()]
     case .stripeCheckoutFail(let paywallInfo):
       return ["event": "stripeCheckoutFail", "paywallInfo": paywallInfo.toJson()]
+    case .paywallPageView(let paywallInfo, let data):
+      return [
+        "event": "paywallPageView",
+        "paywallInfo": paywallInfo.toJson(),
+        "data": data.toJson()
+      ]
     default:
       return ["event": "unknown"]
     }

--- a/ios/SuperwallExpo.podspec
+++ b/ios/SuperwallExpo.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency "SuperwallKit", '4.14.1'
+  s.dependency "SuperwallKit", '4.15.1'
 
 
   # Swift/Objective-C compatibility

--- a/src/SuperwallExpoModule.types.ts
+++ b/src/SuperwallExpoModule.types.ts
@@ -372,8 +372,146 @@ export interface ComputedPropertyRequest {
 }
 
 /**
+ * The store that backs a {@link Product}.
+ * - `APP_STORE`: Apple App Store product (iOS).
+ * - `PLAY_STORE`: Google Play Store product (Android).
+ * - `STRIPE`: Stripe-managed product.
+ * - `PADDLE`: Paddle-managed product.
+ * - `SUPERWALL`: Manually granted entitlement from the Superwall dashboard.
+ * - `CUSTOM`: A custom product purchased through a `PurchaseController` outside of any
+ *   storefront. When you receive a custom product in `onPurchase`, you must implement the
+ *   purchase yourself (e.g., calling your backend) instead of going through StoreKit / Billing.
+ * - `OTHER`: An unknown or unsupported store.
+ */
+export type ProductStore =
+  | "APP_STORE"
+  | "PLAY_STORE"
+  | "STRIPE"
+  | "PADDLE"
+  | "SUPERWALL"
+  | "CUSTOM"
+  | "OTHER"
+
+/**
+ * The Apple App Store-specific data for a {@link Product}.
+ */
+export interface AppStoreProductIdentifier {
+  /** The App Store product identifier. */
+  id: string
+}
+
+/**
+ * The Stripe-specific data for a {@link Product}.
+ */
+export interface StripeProductIdentifier {
+  /** The Stripe price/product identifier. */
+  id: string
+  /** The number of trial days for this product, if any. */
+  trialDays?: number
+}
+
+/**
+ * The Paddle-specific data for a {@link Product}.
+ */
+export interface PaddleProductIdentifier {
+  /** The Paddle product identifier. */
+  id: string
+}
+
+/**
+ * The custom-product data for a {@link Product}.
+ * Custom products are purchased via your `PurchaseController` rather than through a storefront.
+ */
+export interface CustomStoreProductIdentifier {
+  /** The custom product identifier (as configured on the Superwall dashboard). */
+  id: string
+}
+
+/**
+ * The offer type that applied to a {@link SubscriptionTransaction}.
+ *
+ * @platform Android
+ */
+export type SubscriptionOfferType =
+  | "trial"
+  | "code"
+  | "subscription"
+  | "promotional"
+  | "winback"
+  | "revoked"
+
+/**
+ * A subscription transaction recorded in the customer's purchase history.
+ *
+ * @platform Android — currently only delivered by the Android SDK.
+ */
+export interface SubscriptionTransaction {
+  /** The unique identifier for the transaction. */
+  transactionId: string
+  /** The product identifier of the subscription. */
+  productId: string
+  /** ISO-8601 timestamp of when the user was charged. */
+  purchaseDate: string
+  /** Whether the subscription is set to renew. */
+  willRenew: boolean
+  /** Whether the transaction has been revoked. */
+  isRevoked: boolean
+  /** Whether the subscription is in a billing grace period. */
+  isInGracePeriod: boolean
+  /** Whether the subscription is in a billing retry period. */
+  isInBillingRetryPeriod: boolean
+  /** Whether the subscription is currently active. */
+  isActive: boolean
+  /** ISO-8601 expiration date, or `null` if non-renewing. */
+  expirationDate?: string | null
+  /** Store the transaction came from (e.g. `"PLAY_STORE"`). */
+  store: string
+  /** Offer type, if any was applied. */
+  offerType?: SubscriptionOfferType
+  /** iOS-only — the subscription group identifier. */
+  subscriptionGroupId?: string
+}
+
+/**
+ * A non-subscription (one-time / consumable) transaction in the customer's purchase history.
+ *
+ * @platform Android — currently only delivered by the Android SDK.
+ */
+export interface NonSubscriptionTransaction {
+  /** The unique identifier for the transaction. */
+  transactionId: string
+  /** The product identifier of the in-app purchase. */
+  productId: string
+  /** ISO-8601 timestamp of when the user was charged. */
+  purchaseDate: string
+  /** Whether the in-app purchase is consumable. */
+  isConsumable: boolean
+  /** Whether the transaction has been revoked. */
+  isRevoked: boolean
+  /** Store the transaction came from (e.g. `"PLAY_STORE"`). */
+  store: string
+}
+
+/**
+ * The latest subscription and entitlement state for the customer.
+ * Snapshots are immutable and don't auto-update.
+ *
+ * @platform Android — currently only delivered by the Android SDK.
+ */
+export interface CustomerInfo {
+  /** The user ID at the time the snapshot was taken. */
+  userId: string
+  /** All subscription transactions, ordered by purchase date ascending. */
+  subscriptions: SubscriptionTransaction[]
+  /** All non-subscription transactions, ordered by purchase date ascending. */
+  nonSubscriptions: NonSubscriptionTransaction[]
+  /** All entitlements available to the user. */
+  entitlements: Entitlement[]
+}
+
+/**
  * Represents a product available for purchase on a paywall, as defined within {@link PaywallInfo}.
- * This provides a simplified view of a product, focusing on its ID, name, and granted entitlements.
+ * This provides a simplified view of a product, focusing on its ID, name, store, and granted entitlements.
  */
 export interface Product {
   /**
@@ -389,6 +527,34 @@ export interface Product {
    * See {@link Entitlement}.
    */
   entitlements: Entitlement[]
+  /**
+   * The store that backs this product. See {@link ProductStore}.
+   * Use this to detect `CUSTOM` products in `onPurchase` and route them to your own
+   * purchase logic instead of StoreKit / Google Play Billing.
+   *
+   * @platform iOS — present on iOS 4.15.0+. May be absent on older Android SDK versions.
+   */
+  store?: ProductStore
+  /**
+   * App Store-specific product data, present when `store === "APP_STORE"`.
+   * @platform iOS
+   */
+  appStoreProduct?: AppStoreProductIdentifier
+  /**
+   * Stripe-specific product data, present when `store === "STRIPE"`.
+   * @platform iOS
+   */
+  stripeProduct?: StripeProductIdentifier
+  /**
+   * Paddle-specific product data, present when `store === "PADDLE"`.
+   * @platform iOS
+   */
+  paddleProduct?: PaddleProductIdentifier
+  /**
+   * Custom-product data, present when `store === "CUSTOM"`.
+   * @platform iOS
+   */
+  customProduct?: CustomStoreProductIdentifier
 }
 
 /**
@@ -402,6 +568,11 @@ export interface PaywallInfo {
   name: string
   /** The URL where the paywall's web content is hosted. */
   url: string
+  /**
+   * A unique identifier for this paywall presentation, used to correlate all events
+   * within a single presentation lifecycle.
+   */
+  presentationId?: string
   /**
    * The experiment associated with this paywall presentation, if applicable.
    * See {@link Experiment}.
@@ -495,6 +666,14 @@ export interface PaywallInfo {
    * Contains key-value pairs representing the paywall's current state.
    */
   state: Record<string, any>
+  /**
+   * A snapshot of the customer's subscription and entitlement state at the time
+   * the paywall was presented.
+   *
+   * @platform Android — currently only populated by the Android SDK (2.7.12+).
+   *   Will be `undefined` on iOS.
+   */
+  customerInfo?: CustomerInfo
 }
 
 /**
@@ -2079,6 +2258,43 @@ export interface StripeCheckoutFailEvent {
 }
 
 /**
+ * Page-specific details for a multi-page paywall page view.
+ */
+export interface PageViewData {
+  /** The unique identifier for the page node. */
+  pageNodeId: string
+  /** The zero-based index of the page in the paywall flow. */
+  flowPosition: number
+  /** The display name of the page. */
+  pageName: string
+  /** The unique identifier for the navigation node. */
+  navigationNodeId: string
+  /** The unique identifier for the previous page node, if any. */
+  previousPageNodeId?: string
+  /** The flow position of the previous page, if any. */
+  previousFlowPosition?: number
+  /**
+   * How the user navigated to the page.
+   * Possible values: `"entry"`, `"forward"`, `"back"`, `"auto_transition"`.
+   */
+  navigationType: string
+  /** Time spent on the previous page in milliseconds, if any. */
+  timeOnPreviousPageMs?: number
+}
+
+/**
+ * The user navigated to a page in a multi-page paywall.
+ */
+export interface PaywallPageViewEvent {
+  /** The user navigated to a page in a multi-page paywall. */
+  event: "paywallPageView"
+  /** Information about the paywall associated with this page view. */
+  paywallInfo: PaywallInfo
+  /** Details about the page that was navigated to. */
+  data: PageViewData
+}
+
+/**
  * A union of all possible string literal values for the `event` property from all specific Superwall event types.
  * This type can be used when you need to refer to an event type name itself.
  */
@@ -2162,6 +2378,7 @@ export type SuperwallEventType =
   | StripeCheckoutSubmitEvent["event"]
   | StripeCheckoutCompleteEvent["event"]
   | StripeCheckoutFailEvent["event"]
+  | PaywallPageViewEvent["event"]
 
 /**
  * Represents a Superwall event that can be tracked by the SDK.
@@ -2248,6 +2465,7 @@ export type SuperwallEvent =
   | StripeCheckoutSubmitEvent
   | StripeCheckoutCompleteEvent
   | StripeCheckoutFailEvent
+  | PaywallPageViewEvent
 
 /**
  * Contains information about a Superwall event, including the specific {@link SuperwallEvent}
@@ -2327,7 +2545,18 @@ export type LogScope =
   | "cache"
   | "all"
 
-export type OnPurchaseParamsIOS = { productId: string; platform: "ios" }
+export type OnPurchaseParamsIOS = {
+  productId: string
+  platform: "ios"
+  /**
+   * The store that backs the product being purchased. See {@link ProductStore}.
+   * When the value is `"CUSTOM"`, the product is not backed by StoreKit and your
+   * purchase handler must implement the purchase itself (e.g., calling your backend).
+   * May be `undefined` if the product cannot be matched against the most recently
+   * presented paywall (e.g., during background flows).
+   */
+  store?: ProductStore
+}
 
 export type OnPurchaseParamsAndroid = {
   productId: string

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -36,6 +36,12 @@ import { filterUndefined } from "../utils/filterUndefined"
 
 export { ComputedPropertyRequest } from "./lib/ComputedPropertyRequest"
 export { ConfigurationStatus } from "./lib/ConfigurationStatus"
+export {
+  CustomerInfo,
+  type SubscriptionTransaction,
+  type NonSubscriptionTransaction,
+  type SubscriptionOfferType,
+} from "./lib/CustomerInfo"
 export { EntitlementsInfo } from "./lib/EntitlementsInfo"
 export { Experiment } from "./lib/Experiment"
 export { FeatureGatingBehavior } from "./lib/FeatureGatingBehavior"
@@ -59,7 +65,14 @@ export {
   PaywallSkippedReasonPlacementNotFound,
   PaywallSkippedReasonUserIsSubscribed,
 } from "./lib/PaywallSkippedReason"
-export { Product } from "./lib/Product"
+export {
+  Product,
+  ProductStore,
+  type AppStoreProductIdentifier,
+  type StripeProductIdentifier,
+  type PaddleProductIdentifier,
+  type CustomStoreProductIdentifier,
+} from "./lib/Product"
 export { PurchaseController } from "./lib/PurchaseController"
 export {
   PurchaseResult,

--- a/src/compat/lib/CustomerInfo.ts
+++ b/src/compat/lib/CustomerInfo.ts
@@ -1,0 +1,95 @@
+import { Entitlement } from "./Entitlement"
+
+/**
+ * @category Models
+ * Offer type that applied to a {@link SubscriptionTransaction}.
+ *
+ * @platform Android
+ */
+export type SubscriptionOfferType =
+  | "trial"
+  | "code"
+  | "subscription"
+  | "promotional"
+  | "winback"
+  | "revoked"
+
+/**
+ * @category Models
+ * A subscription transaction in the customer's purchase history.
+ *
+ * @platform Android — currently only delivered by the Android SDK (2.7.12+).
+ */
+export interface SubscriptionTransaction {
+  transactionId: string
+  productId: string
+  /** ISO-8601 string. */
+  purchaseDate: string
+  willRenew: boolean
+  isRevoked: boolean
+  isInGracePeriod: boolean
+  isInBillingRetryPeriod: boolean
+  isActive: boolean
+  /** ISO-8601 string, or `null` if non-renewing. */
+  expirationDate?: string | null
+  store: string
+  offerType?: SubscriptionOfferType
+  subscriptionGroupId?: string
+}
+
+/**
+ * @category Models
+ * A non-subscription (one-time / consumable) transaction.
+ *
+ * @platform Android — currently only delivered by the Android SDK (2.7.12+).
+ */
+export interface NonSubscriptionTransaction {
+  transactionId: string
+  productId: string
+  /** ISO-8601 string. */
+  purchaseDate: string
+  isConsumable: boolean
+  isRevoked: boolean
+  store: string
+}
+
+/**
+ * @category Models
+ * Snapshot of the customer's subscription and entitlement state.
+ *
+ * @platform Android — currently only delivered by the Android SDK (2.7.12+).
+ */
+export class CustomerInfo {
+  userId: string
+  subscriptions: SubscriptionTransaction[]
+  nonSubscriptions: NonSubscriptionTransaction[]
+  entitlements: Entitlement[]
+
+  constructor({
+    userId,
+    subscriptions,
+    nonSubscriptions,
+    entitlements,
+  }: {
+    userId: string
+    subscriptions: SubscriptionTransaction[]
+    nonSubscriptions: NonSubscriptionTransaction[]
+    entitlements: Entitlement[]
+  }) {
+    this.userId = userId
+    this.subscriptions = subscriptions
+    this.nonSubscriptions = nonSubscriptions
+    this.entitlements = entitlements
+  }
+
+  static fromJson(json: any): CustomerInfo {
+    return new CustomerInfo({
+      userId: json.userId ?? "",
+      subscriptions: Array.isArray(json.subscriptions) ? json.subscriptions : [],
+      nonSubscriptions: Array.isArray(json.nonSubscriptions) ? json.nonSubscriptions : [],
+      entitlements: Array.isArray(json.entitlements)
+        ? json.entitlements.map((e: any) => Entitlement.fromJson(e))
+        : [],
+    })
+  }
+}

--- a/src/compat/lib/PaywallInfo.ts
+++ b/src/compat/lib/PaywallInfo.ts
@@ -1,4 +1,5 @@
 import { ComputedPropertyRequest } from "./ComputedPropertyRequest"
+import { CustomerInfo } from "./CustomerInfo"
 import { Experiment } from "./Experiment"
 import { type FeatureGatingBehavior, featureGatingBehaviorFromJson } from "./FeatureGatingBehavior"
 import { LocalNotification } from "./LocalNotification"
@@ -15,6 +16,7 @@ export class PaywallInfo {
   identifier: string
   name: string
   url: string
+  presentationId?: string
   experiment?: Experiment
   products: Product[]
   productIds: string[]
@@ -43,11 +45,17 @@ export class PaywallInfo {
   computedPropertyRequests: ComputedPropertyRequest[] // Assuming ComputedPropertyRequest is defined elsewhere
   surveys: Survey[] // Assuming Survey is defined elsewhere
   state: Record<string, any>
+  /**
+   * Snapshot of the customer's subscription/entitlement state.
+   * Currently only populated by the Android SDK (2.7.12+).
+   */
+  customerInfo?: CustomerInfo
 
   constructor({
     identifier,
     name,
     url,
+    presentationId,
     experiment,
     products,
     productIds,
@@ -76,10 +84,12 @@ export class PaywallInfo {
     computedPropertyRequests,
     surveys,
     state,
+    customerInfo,
   }: {
     identifier: string
     name: string
     url: string
+    presentationId?: string
     experiment?: Experiment
     products: Product[]
     productIds: string[]
@@ -108,10 +118,12 @@ export class PaywallInfo {
     computedPropertyRequests: ComputedPropertyRequest[]
     surveys: Survey[]
     state: Record<string, any>
+    customerInfo?: CustomerInfo
   }) {
     this.identifier = identifier
     this.name = name
     this.url = url
+    this.presentationId = presentationId
     this.experiment = experiment
     this.products = products
     this.productIds = productIds
@@ -140,6 +152,7 @@ export class PaywallInfo {
     this.computedPropertyRequests = computedPropertyRequests
     this.surveys = surveys
     this.state = state
+    this.customerInfo = customerInfo
   }
 
   static fromJson(json: any): PaywallInfo {
@@ -147,6 +160,7 @@ export class PaywallInfo {
       identifier: json.identifier,
       name: json.name,
       url: json.url,
+      presentationId: json.presentationId,
       experiment: json.experiment ? Experiment.fromJson(json.experiment) : undefined,
       products: json.products?.map((p: any) => Product.fromJson(p)),
       productIds: json.productIds,
@@ -177,6 +191,7 @@ export class PaywallInfo {
       ),
       surveys: json.surveys?.map((s: any) => Survey.fromJson(s)),
       state: json.state ?? {},
+      customerInfo: json.customerInfo ? CustomerInfo.fromJson(json.customerInfo) : undefined,
     })
   }
 }

--- a/src/compat/lib/Product.ts
+++ b/src/compat/lib/Product.ts
@@ -1,6 +1,58 @@
 import { Entitlement } from "./Entitlement"
 
 /**
+ * @category Enums
+ * The store that backs a {@link Product}.
+ *
+ * - `APP_STORE`: Apple App Store product (iOS).
+ * - `PLAY_STORE`: Google Play Store product (Android).
+ * - `STRIPE`: Stripe-managed product.
+ * - `PADDLE`: Paddle-managed product.
+ * - `SUPERWALL`: Manually granted entitlement from the Superwall dashboard.
+ * - `CUSTOM`: Purchased via your own `PurchaseController` (no storefront).
+ * - `OTHER`: Unknown store.
+ */
+export enum ProductStore {
+  appStore = "APP_STORE",
+  playStore = "PLAY_STORE",
+  stripe = "STRIPE",
+  paddle = "PADDLE",
+  superwall = "SUPERWALL",
+  custom = "CUSTOM",
+  other = "OTHER",
+}
+
+/**
+ * The Apple App Store-specific data for a {@link Product}.
+ */
+export interface AppStoreProductIdentifier {
+  id: string
+}
+
+/**
+ * The Stripe-specific data for a {@link Product}.
+ */
+export interface StripeProductIdentifier {
+  id: string
+  trialDays?: number
+}
+
+/**
+ * The Paddle-specific data for a {@link Product}.
+ */
+export interface PaddleProductIdentifier {
+  id: string
+}
+
+/**
+ * The custom-product data for a {@link Product}.
+ * Custom products are purchased via your `PurchaseController` rather than through a storefront.
+ */
+export interface CustomStoreProductIdentifier {
+  id: string
+}
+
+/**
  * @category Models
  * @since 0.0.15
  * Represents a product that can be purchased.
@@ -9,19 +61,43 @@ export class Product {
   name?: string
   id: string
   entitlements: Set<Entitlement>
+  /**
+   * The store that backs this product. May be `undefined` on older native SDK
+   * versions that don't bridge the field.
+   */
+  store?: ProductStore
+  appStoreProduct?: AppStoreProductIdentifier
+  stripeProduct?: StripeProductIdentifier
+  paddleProduct?: PaddleProductIdentifier
+  customProduct?: CustomStoreProductIdentifier
 
   constructor({
     id,
     name,
     entitlements,
+    store,
+    appStoreProduct,
+    stripeProduct,
+    paddleProduct,
+    customProduct,
   }: {
     id: string
     name?: string
     entitlements: Set<Entitlement>
+    store?: ProductStore
+    appStoreProduct?: AppStoreProductIdentifier
+    stripeProduct?: StripeProductIdentifier
+    paddleProduct?: PaddleProductIdentifier
+    customProduct?: CustomStoreProductIdentifier
   }) {
     this.id = id
     this.name = name
     this.entitlements = entitlements
+    this.store = store
+    this.appStoreProduct = appStoreProduct
+    this.stripeProduct = stripeProduct
+    this.paddleProduct = paddleProduct
+    this.customProduct = customProduct
   }
 
   // Factory method to create a Product instance from a JSON object
@@ -34,6 +110,11 @@ export class Product {
           ? json.entitlements.map((item: any) => Entitlement.fromJson(item))
           : [],
       ),
+      store: json.store as ProductStore | undefined,
+      appStoreProduct: json.appStoreProduct,
+      stripeProduct: json.stripeProduct,
+      paddleProduct: json.paddleProduct,
+      customProduct: json.customProduct,
     })
   }
 }

--- a/src/compat/lib/SuperwallEventInfo.ts
+++ b/src/compat/lib/SuperwallEventInfo.ts
@@ -116,6 +116,23 @@ export enum EventType {
   stripeCheckoutSubmit = "stripeCheckoutSubmit",
   stripeCheckoutComplete = "stripeCheckoutComplete",
   stripeCheckoutFail = "stripeCheckoutFail",
+  paywallPageView = "paywallPageView",
+}
+
+/**
+ * @category Models
+ * Page-specific details for a multi-page paywall page view.
+ */
+export interface PageViewData {
+  pageNodeId: string
+  flowPosition: number
+  pageName: string
+  navigationNodeId: string
+  previousPageNodeId?: string
+  previousFlowPosition?: number
+  /** `"entry"` | `"forward"` | `"back"` | `"auto_transition"` */
+  navigationType: string
+  timeOnPreviousPageMs?: number
 }
 
 /**
@@ -151,6 +168,7 @@ export class SuperwallEvent {
   errorMessage?: string
   userEnrichment?: Record<string, any>
   deviceEnrichment?: Record<string, any>
+  pageViewData?: PageViewData
 
   private constructor(options: {
     type: EventType
@@ -186,6 +204,7 @@ export class SuperwallEvent {
     errorMessage?: string
     userEnrichment?: Record<string, any>
     deviceEnrichment?: Record<string, any>
+    pageViewData?: PageViewData
   }) {
     Object.assign(this, options)
   }
@@ -421,6 +440,12 @@ export class SuperwallEvent {
         return new SuperwallEvent({
           type: eventType,
           paywallInfo: PaywallInfo.fromJson(json.paywallInfo),
+        })
+      case EventType.paywallPageView:
+        return new SuperwallEvent({
+          type: eventType,
+          paywallInfo: PaywallInfo.fromJson(json.paywallInfo),
+          pageViewData: json.data,
         })
       default:
         console.warn(`[Superwall] Unhandled event type in SuperwallEvent.fromJson: ${json.event}`)


### PR DESCRIPTION
## Summary

Bumps both native SDKs and bridges the new public surface added between releases.

### iOS — SuperwallKit `4.14.1` → `4.15.1`

- New `paywallPageView` event for multipage paywall navigation tracking, with `PageViewData` payload (`pageNodeId`, `flowPosition`, `pageName`, `navigationNodeId`, `navigationType`, plus optional previous-page fields and `timeOnPreviousPageMs`).
- `PaywallInfo.presentationId` is bridged so events within a single presentation can be correlated.
- **CustomStoreProduct support**: `Product` now carries `store` (`APP_STORE` | `STRIPE` | `PADDLE` | `PLAY_STORE` | `SUPERWALL` | `CUSTOM` | `OTHER`) plus per-store identifier objects (`appStoreProduct`, `stripeProduct`, `paddleProduct`, `customProduct`). The `onPurchase` callback also receives `store`, so JS can route `CUSTOM` products to its own purchase logic instead of StoreKit:
  ```ts
  onPurchase: async (params) => {
    if (params.platform === "ios" && params.store === "CUSTOM") {
      return await myBackend.charge(params.productId)
    }
    // …normal StoreKit flow
  }
  ```
- `ProductStore+Json.swift` now handles the new `.custom` case + `@unknown default` for forward compatibility.

### Android — Superwall-Android `2.7.11` → `2.7.12`

- Bridges the new `PaywallInfo.customerInfo` (`subscriptions`, `nonSubscriptions`, `entitlements`, `userId`) — currently Android-only on `PaywallInfo`, so the TS field is typed as optional.
- Picks up upstream improvements: intro-offer eligibility logic for Stripe/Paddle products, bottom-sheet dismiss fix on newer Samsung devices.

### Other 4.15.x iOS items considered and skipped

- `onCustomCallback` parameter on `getPaywall` — Expo doesn't expose `getPaywall`; the equivalent path through `register`/`usePlacement` already supports `onCustomCallback`.
- `SuperwallOptions.localResources` accepting `UIImage` — `localResources` isn't exposed in Expo at all yet.
- Internal fixes (price formatter rounding, sanitized email, abandoned-transaction audience filter params) — no public surface change.

## Test plan

- [ ] `tsc --noEmit` passes (verified locally).
- [ ] `expo-module build` produces type defs containing `PageViewData`, `PaywallPageViewEvent`, `presentationId`, `ProductStore`, `customProduct`, `customerInfo` (verified locally).
- [ ] Run example app on iOS simulator with a paywall configured with custom products; confirm `onPurchase` receives `{ store: "CUSTOM" }` for custom products and the JS-side handler is responsible for the purchase.
- [ ] Run example app on iOS simulator with a multi-page paywall; confirm `paywallPageView` event fires on page navigation with `data.pageName` populated.
- [ ] Run example app on Android device; confirm `paywallInfo.customerInfo` is populated with the user's subscription/entitlement state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps iOS SuperwallKit from 4.14.1 → 4.15.1 and Android SDK from 2.7.11 → 2.7.12, bridging the new public surface: multi-page paywall tracking (`paywallPageView` + `PageViewData`), `PaywallInfo.presentationId`, custom store product routing in `onPurchase`, and Android-only `customerInfo` on `PaywallInfo`. The implementation follows the established native serialisation pattern consistently across Swift and Kotlin, and the TypeScript types are well-documented with platform annotations.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all findings are P2; no correctness or security issues on the critical purchase path.

Only P2 findings: an implicit dependency on Android SDK enum constant naming for offerType, and a documented edge case where storeForProductIdentifier silently returns nil. Neither affects correctness in the expected paths tested by the PR author.

android/src/main/java/expo/modules/superwallexpo/json/CustomerInfo.kt (offerType enum mapping) and ios/Bridges/PurchaseControllerBridge.swift (latestPaywallInfo lookup edge case).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| android/src/main/java/expo/modules/superwallexpo/json/CustomerInfo.kt | New file bridging Android CustomerInfo, SubscriptionTransaction, and NonSubscriptionTransaction to JSON; offerType enum mapping via .name.lowercase() implicitly depends on SDK constant naming conventions. |
| ios/Bridges/PurchaseControllerBridge.swift | Adds storeForProductIdentifier lookup via latestPaywallInfo to include store in onPurchase payload; lookup can silently return nil in edge cases (dismissed paywall), potentially hiding the CUSTOM store signal from JS. |
| ios/Json/Product+Json.swift | New file; bridges all product store types (APP_STORE, STRIPE, PADDLE, CUSTOM) via a switch on type; relies on existing per-type +Json extensions. Clean implementation. |
| src/SuperwallExpoModule.types.ts | Adds ProductStore, per-store identifier interfaces, CustomerInfo, PageViewData, PaywallPageViewEvent, and extends OnPurchaseParamsIOS and PaywallInfo; all new types are well-documented and correctly integrated into the event union types. |
| src/compat/lib/CustomerInfo.ts | New compat class for CustomerInfo with defensive fromJson (null checks on arrays, ?? '' for userId); clean implementation. |
| src/compat/lib/SuperwallEventInfo.ts | Adds paywallPageView to EventType enum and pageViewData field to SuperwallEvent, with correct fromJson case; json.data is assigned without a typed factory, consistent with the surrounding pattern. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SW as SuperwallKit (Native)
    participant Bridge as PurchaseControllerBridge (iOS)
    participant RN as JS / React Native
    participant BE as App Backend

    SW->>Bridge: purchase(product: StoreProduct)
    Bridge->>SW: latestPaywallInfo?.products (MainActor)
    SW-->>Bridge: Product? (with store enum)
    Bridge->>RN: emit onPurchase { productId, platform:"ios", store? }
    alt store == "CUSTOM"
        RN->>BE: myBackend.charge(productId)
        BE-->>RN: success
        RN->>Bridge: purchaseResult(purchased)
    else store == "APP_STORE" or store missing
        RN->>Bridge: purchaseResult(purchased)
    end
    Bridge-->>SW: PurchaseResult

    SW->>RN: emit paywallPageView { paywallInfo, data: PageViewData }
    Note over RN: pageNodeId, flowPosition, navigationType, ...
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: android/src/main/java/expo/modules/superwallexpo/json/CustomerInfo.kt
Line: 36

Comment:
**`offerType` mapping relies on Android SDK enum constant names**

`it.name.lowercase()` produces a string whose exact value depends on how the Android SDK names its `OfferType` (or equivalent) enum constants — e.g., `TRIAL` → `"trial"`, `PROMOTIONAL` → `"promotional"`. The TypeScript `SubscriptionOfferType` union lists exactly those lowercase values, so the mapping is correct only if the SDK constants match. If the SDK uses a different naming convention (e.g., `FREE_TRIAL` instead of `TRIAL`), the emitted strings would silently fall outside the TS type without a compile-time or runtime error. Consider mapping each case explicitly (or at least verifying and documenting the SDK enum constant names) to make the dependency visible.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: ios/Bridges/PurchaseControllerBridge.swift
Line: 34-37

Comment:
**Silent store-lookup miss drops the `CUSTOM` signal for JS routing**

`latestPaywallInfo` is read after `await`-ing a main-actor hop, so it reflects the paywall state at that instant. If the paywall is dismissed by Superwall before the `purchase` callback fires (e.g., during certain error or background flows), `latestPaywallInfo` may already be `nil` or point to a different paywall, and `store` is silently omitted from the payload. For `APP_STORE` products that is harmless, but for `CUSTOM` products the omission means JS never sees `store: "CUSTOM"` and must fall through to the default StoreKit path — which for a custom product would fail or produce incorrect behaviour.

The TypeScript type already documents this with `store?: ProductStore`, but consider emitting a console warning on the native side when `store` cannot be resolved so developers can catch the edge case during integration testing.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: bump iOS to 4.15.1 + Android to 2...."](https://github.com/superwall/expo-superwall/commit/0c3396d27bd4e459d0575ae3c41315288140437e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30035381)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->