### PR TITLE
[SW-5108] Fix callback pending in register

### DIFF
--- a/.changeset/bitter-shrimps-vanish.md
+++ b/.changeset/bitter-shrimps-vanish.md
@@ -1,0 +1,5 @@
+---
+"expo-superwall": patch
+---
+
+Ensure register callbacks resolve properly in all cases

--- a/src/__tests__/sdk.behavior.test.tsx
+++ b/src/__tests__/sdk.behavior.test.tsx
@@ -140,8 +140,17 @@ describe("SDK behavior regressions", () => {
     })
   })
 
-  it("does not run the placement feature immediately and runs it on skip", async () => {
-    const registerPlacement = jest.fn().mockResolvedValue(undefined)
+  it("runs the placement feature when the native register promise resolves (Non-Gated dismiss, skip, purchased)", async () => {
+    // Mirror native semantics: the promise only resolves when the SDK invokes
+    // its feature closure — i.e. when access should be granted. Gated declines
+    // never resolve the promise.
+    let resolveRegister: (() => void) | undefined
+    const registerPlacement = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRegister = resolve
+        }),
+    )
     const feature = jest.fn()
     let placementApi: ReturnType<typeof usePlacement> | undefined
 
@@ -161,114 +170,53 @@ describe("SDK behavior regressions", () => {
       )
     })
 
-    await act(async () => {
+    // Non-Gated dismiss (regression for #185): native fires feature closure on
+    // dismiss-without-purchase, so the promise resolves and feature must run.
+    let pending = act(async () => {
       await placementApi!.registerPlacement({
-        placement: "test-placement",
+        placement: "non-gated-placement",
         feature,
       })
     })
 
     expect(feature).not.toHaveBeenCalled()
-
-    const handlerId = registerPlacement.mock.calls[0][2]
-
     act(() => {
-      emit("onPaywallSkip", {
-        skippedReason: { type: "NoAudienceMatch" },
-        handlerId,
-      })
+      resolveRegister?.()
     })
-
+    await pending
     expect(feature).toHaveBeenCalledTimes(1)
-    act(() => {
-      renderer!.unmount()
-    })
-  })
 
-  it("runs the placement feature only for purchased/restored dismissals", async () => {
-    const registerPlacement = jest.fn().mockResolvedValue(undefined)
-    const feature = jest.fn()
-    let placementApi: ReturnType<typeof usePlacement> | undefined
-
-    useSuperwallStore.setState({ registerPlacement })
-
-    function Harness() {
-      placementApi = usePlacement()
-      return null
-    }
-
-    let renderer: TestRenderer.ReactTestRenderer
-    act(() => {
-      renderer = TestRenderer.create(
-        <SuperwallContext.Provider value={true}>
-          <Harness />
-        </SuperwallContext.Provider>,
-      )
-    })
-
-    await act(async () => {
+    // Skip: native also resolves the promise via its feature closure.
+    pending = act(async () => {
       await placementApi!.registerPlacement({
-        placement: "declined-placement",
+        placement: "skipped-placement",
         feature,
       })
     })
-
-    let handlerId = registerPlacement.mock.calls[0][2]
-
     act(() => {
-      emit("onPaywallDismiss", {
-        paywallInfoJson: { name: "declined" },
-        result: { type: "declined" },
-        handlerId,
-      })
+      resolveRegister?.()
     })
+    await pending
+    expect(feature).toHaveBeenCalledTimes(2)
 
-    expect(feature).not.toHaveBeenCalled()
-
-    await act(async () => {
-      await placementApi!.registerPlacement({
-        placement: "purchased-placement",
+    // Gated decline: native never invokes the feature closure, so the promise
+    // never resolves and feature never runs. We assert by ticking the event
+    // loop without resolving the pending promise.
+    let unresolved = true
+    placementApi!
+      .registerPlacement({
+        placement: "gated-placement",
         feature,
       })
-    })
-
-    handlerId = registerPlacement.mock.calls[1][2]
-
-    act(() => {
-      emit("onPaywallDismiss", {
-        paywallInfoJson: { name: "purchased" },
-        result: { type: "purchased", productId: "pro" },
-        handlerId,
+      .then(() => {
+        unresolved = false
       })
-    })
-
-    expect(feature).toHaveBeenCalledTimes(1)
-
     await act(async () => {
-      await placementApi!.registerPlacement({
-        placement: "errored-placement",
-        feature,
-      })
+      await Promise.resolve()
     })
+    expect(unresolved).toBe(true)
+    expect(feature).toHaveBeenCalledTimes(2)
 
-    handlerId = registerPlacement.mock.calls[2][2]
-
-    act(() => {
-      emit("onPaywallError", {
-        errorString: "boom",
-        handlerId,
-      })
-    })
-
-    act(() => {
-      emit("onPaywallDismiss", {
-        paywallInfoJson: { name: "post-error" },
-        result: { type: "restored" },
-        handlerId,
-      })
-    })
-
-    expect(feature).toHaveBeenCalledTimes(1)
     act(() => {
       renderer!.unmount()
     })

--- a/src/usePlacement.ts
+++ b/src/usePlacement.ts
@@ -125,21 +125,16 @@ export function usePlacement(callbacks: usePlacementCallbacks = {}) {
     handlerId: id,
     onPaywallDismiss(info, result) {
       setState({ status: "dismissed", result })
-      if (result.type === "purchased" || result.type === "restored") {
-        runPendingFeature()
-      } else {
-        clearPendingFeature()
-      }
-
       callbacks.onDismiss?.(info, result)
     },
     onPaywallSkip(reason) {
       setState({ status: "skipped", reason })
-      runPendingFeature()
       callbacks.onSkip?.(reason)
     },
     onPaywallError(error) {
       setState({ status: "error", error })
+      // Native won't resolve the register promise on error, so drop the pending
+      // feature here to avoid firing it on a later unrelated registerPlacement.
       clearPendingFeature()
       callbacks.onError?.(error)
     },
@@ -155,17 +150,23 @@ export function usePlacement(callbacks: usePlacementCallbacks = {}) {
   }))
 
   /* -------------------- Helpers -------------------- */
+  // The native module passes a feature closure to Superwall.register; that closure
+  // resolves this promise. The native SDK only invokes it when access is granted —
+  // including Non-Gated dismissals, skips, and successful purchases — so awaiting
+  // the promise is the correct gate for running `feature`. Letting JS infer this
+  // from dismiss `result.type` is wrong: it can't distinguish Gated from Non-Gated.
   const registerPlacement = useCallback(
     async ({ placement, params, feature }: RegisterPlacementArgs) => {
       pendingFeatureRef.current = feature
       try {
         await storeRegisterPlacement(placement, params, id)
+        runPendingFeature()
       } catch (error) {
-        pendingFeatureRef.current = undefined
+        clearPendingFeature()
         throw error
       }
     },
-    [storeRegisterPlacement, id],
+    [storeRegisterPlacement, id, runPendingFeature, clearPendingFeature],
   )
 
   return {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression where the `feature` callback passed to `registerPlacement` was not invoked for Non-Gated dismissals. The root cause was that the JS layer was gating feature execution on `result.type` (purchase/restored), which cannot distinguish Gated from Non-Gated paywalls. The fix delegates that decision entirely to the native SDK by awaiting the `storeRegisterPlacement` promise — which only resolves when the native feature closure is invoked.

- **`usePlacement.ts`**: Removes feature execution from `onPaywallSkip` and `onPaywallDismiss` handlers; `runPendingFeature()` is now called only when the native `register` promise resolves. The `onPaywallError` handler retains `clearPendingFeature()` to drop a stale ref when no promise resolution will follow.
- **`sdk.behavior.test.tsx`**: Replaces event-emission-based tests with a promise-control model that directly mirrors native semantics, covering the Non-Gated dismiss, skip, and Gated decline scenarios.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; the fix correctly moves responsibility for feature gating to the native SDK's promise, matching the documented contract.

The new promise-driven model is logically sound and the tests cover the primary cases. The one gap is that after a Gated decline the pendingFeatureRef is never explicitly cleared — the old event-based path did clear it — so the ref holds the feature function until the next registerPlacement call or component unmount. This is a silent discard rather than a wrong invocation, but callers who re-use the same hook instance after a declined gated paywall may find feature1 is quietly dropped.

The re-registration scenario in src/usePlacement.ts (lines 158–170) is worth a second look for apps that call registerPlacement more than once on the same hook instance.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/usePlacement.ts | Core logic refactor: moves feature execution from event-driven (onPaywallSkip/onPaywallDismiss) to promise-driven, resolving when the native feature closure fires. One subtle concern around indefinite pendingFeatureRef retention after a Gated decline. |
| src/__tests__/sdk.behavior.test.tsx | Test rewrite aligns with new promise-based semantics; covers Non-Gated dismiss, skip (resolve path), and Gated decline (non-resolve path). Previous event-driven test cases removed in favor of the simplified promise mock. |
| .changeset/bitter-shrimps-vanish.md | Adds a patch-level changeset entry for this bug fix. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as React App
    participant Hook as usePlacement
    participant Native as Native SDK

    Note over App,Native: Non-Gated dismiss / Skip / Purchase (feature runs)
    App->>Hook: "registerPlacement({ placement, feature })"
    Hook->>Hook: "pendingFeatureRef.current = feature"
    Hook->>Native: storeRegisterPlacement(placement, params, id)
    Native-->>Hook: onPaywallPresent event
    Hook->>Hook: setState(presented)
    Native-->>Hook: onPaywallDismiss / onPaywallSkip event
    Hook->>Hook: setState(dismissed/skipped) — no feature call
    Native-->>Hook: Promise resolves (feature closure invoked)
    Hook->>Hook: runPendingFeature()
    Hook->>App: feature()
    Hook-->>App: registerPlacement resolves

    Note over App,Native: Gated decline (feature never runs)
    App->>Hook: "registerPlacement({ placement, feature })"
    Hook->>Hook: "pendingFeatureRef.current = feature"
    Hook->>Native: storeRegisterPlacement(placement, params, id)
    Native-->>Hook: onPaywallDismiss (declined) event
    Hook->>Hook: setState(dismissed) — pendingFeatureRef unchanged
    Note over Native,Hook: Native never invokes feature closure — promise stays pending

    Note over App,Native: Error path (feature cleared)
    App->>Hook: "registerPlacement({ placement, feature })"
    Hook->>Hook: "pendingFeatureRef.current = feature"
    Hook->>Native: storeRegisterPlacement(placement, params, id)
    Native-->>Hook: onPaywallError event
    Hook->>Hook: clearPendingFeature() — prevents stale execution
    Native-->>Hook: Promise rejects
    Hook->>Hook: clearPendingFeature() (catch block)
    Hook-->>App: throws error
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/usePlacement.ts:158-170
**Stale `pendingFeatureRef` after Gated decline**

After a Gated decline the native promise never resolves, so `pendingFeatureRef.current` retains the `feature` reference indefinitely within the hook instance. Unlike the old `onPaywallDismiss` path (which called `clearPendingFeature()` for declines), the new code has no cleanup triggered by the dismiss event. In practice this only becomes observable if the same `usePlacement` instance calls `registerPlacement` again before a component unmount — the second call overwrites the ref, so `feature1` is silently discarded without running. For most single-call patterns this is harmless, but it may be unexpected for callers that re-register on the same hook instance after a declined gated paywall.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changeset): Ensure register callbac..."](https://github.com/superwall/expo-superwall/commit/a03889a4b15b3e1fd4e50a531361108649dd59ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31160626)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->