### PR TITLE
docs(changeset): Bump Android & iOS versions

### DIFF
--- a/.changeset/cruel-humans-feel.md
+++ b/.changeset/cruel-humans-feel.md
@@ -1,0 +1,5 @@
+---
+"expo-superwall": patch
+---
+
+Bump Android & iOS versions

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-  implementation "com.superwall.sdk:superwall-android:2.7.13"
+  implementation "com.superwall.sdk:superwall-android:2.7.15"
   implementation 'com.android.billingclient:billing:8.0.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.2'
 }

--- a/ios/SuperwallExpo.podspec
+++ b/ios/SuperwallExpo.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency "SuperwallKit", '4.15.1'
+  s.dependency "SuperwallKit", '4.15.3'
 
 
   # Swift/Objective-C compatibility


### PR DESCRIPTION
Bumps Android & iOS versions

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the native Superwall SDK dependencies to their latest patch releases on both platforms and adds the corresponding changeset entry.

- **Android**: `superwall-android` upgraded from `2.7.13` → `2.7.15`
- **iOS**: `SuperwallKit` upgraded from `4.15.1` → `4.15.3`
- **Changeset**: a new `patch` changeset entry is added for `expo-superwall` to track this release

<h3>Confidence Score: 5/5</h3>

Straightforward patch-version dependency bumps on both platforms with no API-surface changes — safe to merge.

Both native SDKs move one or two patch versions forward, the changeset file is correctly formatted, and no bridging code or TypeScript types were touched. The only risk is an undocumented breaking change hiding inside a patch release of either SDK, but that is a standard dependency-update concern rather than anything introduced by this PR itself.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/cruel-humans-feel.md | New changeset file marking this as a patch release for expo-superwall with the Android & iOS version bump description. |
| android/build.gradle | Bumps the superwall-android dependency from 2.7.13 to 2.7.15 (patch update). |
| ios/SuperwallExpo.podspec | Bumps the SuperwallKit CocoaPod dependency from 4.15.1 to 4.15.3 (patch update). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[expo-superwall package] --> B[Android Bridge]
    A --> C[iOS Bridge]
    B -->|superwall-android| D["2.7.13 → 2.7.15"]
    C -->|SuperwallKit CocoaPod| E["4.15.1 → 4.15.3"]
    A --> F[Changeset: patch release]
```

<sub>Reviews (1): Last reviewed commit: ["docs(changeset): Bump Android &amp; iOS vers..."](https://github.com/superwall/expo-superwall/commit/09f75383dac995ae9f8d1a60901d761bad52edcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33212161)</sub>

<!-- /greptile_comment -->