### PR TITLE
feat(android): bridge paywallPageView multi-page analytics event

### DIFF
--- a/android/src/main/java/expo/modules/superwallexpo/json/PageViewData.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/json/PageViewData.kt
@@ -1,0 +1,17 @@
+package expo.modules.superwallexpo.json
+
+import com.superwall.sdk.paywall.view.webview.messaging.PageViewData
+
+fun PageViewData.toJson(): Map<String, Any> {
+  val map = mutableMapOf<String, Any>(
+    "pageNodeId" to pageNodeId,
+    "flowPosition" to flowPosition,
+    "pageName" to pageName,
+    "navigationNodeId" to navigationNodeId,
+    "navigationType" to navigationType,
+  )
+  previousPageNodeId?.let { map["previousPageNodeId"] = it }
+  previousFlowPosition?.let { map["previousFlowPosition"] = it }
+  timeOnPreviousPageMs?.let { map["timeOnPreviousPageMs"] = it }
+  return map
+}

--- a/android/src/main/java/expo/modules/superwallexpo/json/SuperwallEvent.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/json/SuperwallEvent.kt
@@ -46,6 +46,11 @@ class SuperwallEvent {
           map["event"] = "paywallClose"
           map["paywallInfo"] = superwallPlacement.paywallInfo.toJson()
         }
+        is SuperwallEvent.PaywallPageView -> {
+          map["event"] = "paywallPageView"
+          map["paywallInfo"] = superwallPlacement.paywallInfo.toJson()
+          map["data"] = superwallPlacement.data.toJson()
+        }
         is SuperwallEvent.PaywallDecline -> {
           map["event"] = "paywallDecline"
           map["paywallInfo"] = superwallPlacement.paywallInfo.toJson()


### PR DESCRIPTION
## What

Bridges the `paywallPageView` analytics event to JavaScript on **Android**, completing the multi-page paywall analytics feature.

When a user navigates between pages of a multi-page paywall, the native SDKs emit a `paywallPageView` event carrying a `PageViewData` payload. This was already wired up everywhere **except** the Android native bridge:

| Layer | Status before |
|---|---|
| iOS bridge (`PageViewData+Json.swift` + case in `SuperwallPlacementInfo+Json.swift`) | ✅ Done |
| TS types (`PageViewData`, `PaywallPageViewEvent`) | ✅ Done |
| Compat layer (`EventType.paywallPageView`, `fromJson` reads `json.data`) | ✅ Done |
| **Android bridge** (`SuperwallEvent.toJson()`) | ❌ Fell through to `else -> {}` — event never reached JS |

## Why

Without the Android case, multi-page paywall page-view analytics silently never fired on Android while working on iOS — a cross-platform parity gap.

## Changes

- **New** `android/.../json/PageViewData.kt` — a `fun PageViewData.toJson()` extension mirroring the iOS `PageViewData+Json.swift` (required fields always present; `previousPageNodeId` / `previousFlowPosition` / `timeOnPreviousPageMs` emitted only when non-null; camelCase keys matching the TS interface). Follows the repo's standalone-`toJson()`-file convention.
- **Edit** `android/.../json/SuperwallEvent.kt` — adds the `is SuperwallEvent.PaywallPageView` case emitting `event`, `paywallInfo`, and `data`, mirroring `SuperwallPlacementInfo+Json.swift`.

Android now emits the identical `{ event: "paywallPageView", paywallInfo, data }` payload iOS already does. **No JS/TS changes needed** — existing `onSuperwallEvent` consumers and compat `SuperwallEvent.fromJson` work unchanged.

## Reviewer notes / verification

- Statically verified against the pinned SDK: `.context/superwall-android`'s CHANGELOG top is `## 2.7.15`, matching `superwall-android:2.7.15` in `android/build.gradle`. Confirmed `SuperwallEvent.PaywallPageView` (a `SuperwallEvent()` subclass with `paywallInfo` + `data`) and the public `PageViewData` data class exist, and all 8 property names/types in the new `toJson()` match exactly.
- A full gradle compile / on-device runtime check was **not** run in my environment (`example/android` isn't prebuilt and the SDK artifact isn't cached locally). Suggested manual check: run the example app on Android, present a multi-page paywall, navigate pages, and confirm `onSuperwallEvent` receives `paywallPageView` with a populated `data` object — matching iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bridges the `paywallPageView` analytics event to JavaScript on Android by adding a new `PageViewData.kt` serializer and a matching `when` branch in `SuperwallEvent.kt`. It closes a cross-platform parity gap where the same event was already fully wired on iOS.

- **`PageViewData.kt`**: New `toJson()` extension that serializes all 8 fields of `PageViewData` to a `Map<String, Any>`, with the three optional trailing fields (`previousPageNodeId`, `previousFlowPosition`, `timeOnPreviousPageMs`) emitted only when non-null — a faithful mirror of `PageViewData+Json.swift`.
- **`SuperwallEvent.kt`**: Adds the `is SuperwallEvent.PaywallPageView` branch emitting `event`, `paywallInfo`, and `data`, placed correctly between `PaywallClose` and `PaywallDecline` in the `when` expression.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both files are narrow serialization additions that cannot regress existing event handling.

The change is a direct, mechanical translation of the already-working iOS serializer into Kotlin. `PageViewData.kt` mirrors `PageViewData+Json.swift` field-for-field with identical key names and the same optional-field guard pattern. The new `when` branch in `SuperwallEvent.kt` follows the same structure as every surrounding case and cannot affect any other event path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| android/src/main/java/expo/modules/superwallexpo/json/PageViewData.kt | New file that faithfully mirrors PageViewData+Json.swift; all 8 fields serialized correctly with optional fields guarded by ?.let. |
| android/src/main/java/expo/modules/superwallexpo/json/SuperwallEvent.kt | Adds PaywallPageView case to the existing when expression; placement and payload structure correctly match the iOS bridge. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Native as Android SDK
    participant Bridge as SuperwallEvent.kt
    participant PVD as PageViewData.kt
    participant JS as JavaScript/TypeScript

    Native->>Bridge: SuperwallEvent.PaywallPageView(paywallInfo, data)
    Bridge->>Bridge: match is SuperwallEvent.PaywallPageView
    Bridge->>Bridge: "map[event] = paywallPageView"
    Bridge->>Bridge: "map[paywallInfo] = paywallInfo.toJson()"
    Bridge->>PVD: data.toJson()
    PVD-->>Bridge: "Map { pageNodeId, flowPosition, pageName, navigationNodeId, navigationType, [previousPageNodeId], [previousFlowPosition], [timeOnPreviousPageMs] }"
    Bridge->>Bridge: "map[data] = ..."
    Bridge->>JS: "onSuperwallEvent({ event, paywallInfo, data })"
```

<sub>Reviews (1): Last reviewed commit: ["feat(android): bridge paywallPageView mu..."](https://github.com/superwall/expo-superwall/commit/68ac36600438bd1a8e7fba522a63b7c1479db050) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34893222)</sub>

<!-- /greptile_comment -->