### PR TITLE
Update podspec versioning

### DIFF
--- a/.changeset/little-moles-heal.md
+++ b/.changeset/little-moles-heal.md
@@ -1,0 +1,5 @@
+---
+"expo-superwall": patch
+---
+
+Update podspec to pick proper iOS target

--- a/ios/SuperwallExpo.podspec
+++ b/ios/SuperwallExpo.podspec
@@ -2,6 +2,35 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
+# expo-superwall supports Expo SDK 53+, and ExpoModulesCore's minimum iOS/tvOS
+# deployment target differs per SDK (15.1 on SDK 53, 16.4 on SDK 56+). We have
+# to land between two hard constraints:
+#   * Lower than ExpoModulesCore's target → Swift refuses to import it
+#     ("module 'ExpoModulesCore' has a minimum deployment target of iOS 16.4").
+#   * Higher than the host app's Podfile platform → CocoaPods refuses to
+#     install ("required a higher minimum deployment target").
+# So we mirror the ExpoModulesCore that's actually installed, never dropping
+# below our own 15.1 floor. One podspec stays correct across every supported
+# SDK (and any future bump) without forcing a value on anyone.
+expo_modules_core_podspec = begin
+  resolved = `node --print "require.resolve('expo-modules-core/package.json')" 2>/dev/null`.strip
+  [
+    (resolved.empty? ? nil : File.join(File.dirname(resolved), 'ExpoModulesCore.podspec')),
+    File.join(__dir__, '..', '..', 'expo-modules-core', 'ExpoModulesCore.podspec'),
+  ].compact.find { |path| File.exist?(path) }
+rescue StandardError
+  # `node` may be unavailable (e.g. resolving from a tarball); fall back to the
+  # 15.1 floor below.
+  nil
+end
+
+expo_modules_core_contents = expo_modules_core_podspec ? File.read(expo_modules_core_podspec) : ''
+
+deployment_target = lambda do |platform, floor|
+  found = expo_modules_core_contents[/:#{platform}\s*=>\s*['"]([\d.]+)['"]/, 1]
+  [floor, found].compact.max_by { |version| Gem::Version.new(version) }
+end
+
 Pod::Spec.new do |s|
   s.name           = 'SuperwallExpo'
   s.version        = package['version']
@@ -11,8 +40,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1',
-    :tvos => '15.1'
+    :ios => deployment_target.call(:ios, '15.1'),
+    :tvos => deployment_target.call(:tvos, '15.1')
   }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/superwall/expo-superwall' }

--- a/ios/SuperwallExpo.podspec
+++ b/ios/SuperwallExpo.podspec
@@ -27,7 +27,7 @@ end
 expo_modules_core_contents = expo_modules_core_podspec ? File.read(expo_modules_core_podspec) : ''
 
 deployment_target = lambda do |platform, floor|
-  found = expo_modules_core_contents[/:#{platform}\s*=>\s*['"]([\d.]+)['"]/, 1]
+  found = expo_modules_core_contents[/:#{platform}\s*=>\s*(['"])([\d.]+)\1/, 2]
   [floor, found].compact.max_by { |version| Gem::Version.new(version) }
 end
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the hardcoded `15.1` iOS/tvOS deployment targets in `SuperwallExpo.podspec` with a dynamic resolver that reads the minimum target directly from the installed `ExpoModulesCore.podspec`, ensuring the podspec stays compatible as Expo SDK bumps its own minimum (e.g., SDK 56+ requires 16.4).

- The resolver tries `node require.resolve` first, falls back to a relative sibling path, and gracefully degrades to the `15.1` floor when neither is found or `node` is unavailable.
- `Gem::Version` is used for correct semver comparison between the floor and the discovered target.
- A new `patch` changeset entry documents the fix.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the dynamic target detection has proper fallback paths and the logic correctly mirrors ExpoModulesCore's minimum across all supported Expo SDK versions.

The resolver, version comparison, and error handling are all correct. The only minor nit is that the regex permits mismatched quote types around the version string, which could theoretically yield a spurious match in an unusual podspec format, but would never occur against the actual ExpoModulesCore podspec.

No files require special attention; ios/SuperwallExpo.podspec carries all the logic and is worth a quick read if the node-resolution path is ever exercised in CI.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/little-moles-heal.md | New changeset file marking a patch release for the podspec deployment target update. |
| ios/SuperwallExpo.podspec | Replaces hardcoded iOS/tvOS 15.1 deployment targets with dynamic detection of ExpoModulesCore's minimum targets, using a two-path resolver (node require.resolve + relative fallback) and Gem::Version comparison. Logic is correct with one minor regex quoting ambiguity. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pod install] --> B[Run node require.resolve\nexpo-modules-core/package.json]
    B --> C{resolved path empty?}
    C -- No --> D[Path: node_modules/expo-modules-core/\nExpoModulesCore.podspec]
    C -- Yes --> E[Fallback: ../../expo-modules-core/\nExpoModulesCore.podspec]
    D --> F{File exists?}
    E --> F
    F -- Yes --> G[Read ExpoModulesCore.podspec contents]
    F -- No --> H[contents = empty string]
    G --> I[Regex: match :ios/:tvos => version]
    H --> I
    I --> J{Version found?}
    J -- Yes --> K[max_by Gem::Version\nfloor vs found]
    J -- No --> L[Use floor: 15.1]
    K --> M[s.platforms = computed target]
    L --> M
    B --> |StandardError| L
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
ios/SuperwallExpo.podspec:30
The regex character class `['"']` on both sides of the version capture allows mismatched quotes (e.g., `'15.1"` would be accepted). Ruby podspecs always use consistent quotes in practice, but a capturing group with a backreference makes the intent explicit and future-proof against unexpected input.

```suggestion
  found = expo_modules_core_contents[/:#{platform}\s*=>\s*(['"])([\d.]+)\1/, 2]
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changeset): Update podspec to pick ..."](https://github.com/superwall/expo-superwall/commit/0aa884e3b7985c6e799b150a40d7f433d175e9fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34906612)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->