### PR TITLE
Await for config

### DIFF
--- a/.changeset/fine-cows-eat.md
+++ b/.changeset/fine-cows-eat.md
@@ -1,0 +1,5 @@
+---
+"expo-superwall": patch
+---
+
+Ensure that methods await for config finish before triggering

--- a/src/__tests__/sdk.behavior.test.tsx
+++ b/src/__tests__/sdk.behavior.test.tsx
@@ -1,10 +1,14 @@
-import React from "react"
 import TestRenderer, { act } from "react-test-renderer"
 
 const mockListeners = new Map<string, Set<(payload: any) => void>>()
 const mockHandleDeepLink = jest.fn().mockResolvedValue(false)
 const mockDidHandleBackPressed = jest.fn()
 const mockDidHandleCustomCallback = jest.fn().mockResolvedValue(undefined)
+const mockConfigure = jest.fn().mockResolvedValue(true)
+const mockGetUserAttributes = jest.fn().mockResolvedValue({})
+const mockGetSubscriptionStatus = jest.fn().mockResolvedValue({ status: "INACTIVE" })
+const mockSetSubscriptionStatus = jest.fn().mockResolvedValue(undefined)
+const mockSetIntegrationAttributes = jest.fn().mockResolvedValue(undefined)
 const mockAddListener = jest.fn(
   (eventName: string, listener: (payload: any) => void): { remove: () => void } => {
     const listeners = mockListeners.get(eventName) ?? new Set()
@@ -25,13 +29,20 @@ const mockAddListener = jest.fn(
 const emit = (eventName: string, payload: any) => {
   const listeners = mockListeners.get(eventName)
   if (!listeners) return
-  listeners.forEach((listener) => listener(payload))
+  for (const listener of listeners) {
+    listener(payload)
+  }
 }
 
 jest.mock("../SuperwallExpoModule", () => ({
   __esModule: true,
   default: {
     addListener: mockAddListener,
+    configure: mockConfigure,
+    getUserAttributes: mockGetUserAttributes,
+    getSubscriptionStatus: mockGetSubscriptionStatus,
+    setSubscriptionStatus: mockSetSubscriptionStatus,
+    setIntegrationAttributes: mockSetIntegrationAttributes,
     handleDeepLink: mockHandleDeepLink,
     didHandleBackPressed: mockDidHandleBackPressed,
     didHandleCustomCallback: mockDidHandleCustomCallback,
@@ -56,7 +67,10 @@ jest.mock("react-native", () => {
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
 const { SuperwallProvider }: typeof import("../SuperwallProvider") = require("../SuperwallProvider")
-const { SuperwallContext, useSuperwallStore }: typeof import("../useSuperwall") = require("../useSuperwall")
+const {
+  SuperwallContext,
+  useSuperwallStore,
+}: typeof import("../useSuperwall") = require("../useSuperwall")
 const { usePlacement }: typeof import("../usePlacement") = require("../usePlacement")
 const { useSuperwallEvents }: typeof import("../useSuperwallEvents") =
   require("../useSuperwallEvents")
@@ -231,8 +245,11 @@ describe("SDK behavior regressions", () => {
     let renderer: TestRenderer.ReactTestRenderer
     await act(async () => {
       renderer = TestRenderer.create(
-        <SuperwallProvider apiKeys={{ android: "android-key" }} onConfigurationError={onConfigurationError}>
-          <></>
+        <SuperwallProvider
+          apiKeys={{ android: "android-key" }}
+          onConfigurationError={onConfigurationError}
+        >
+          {null}
         </SuperwallProvider>,
       )
 
@@ -252,6 +269,74 @@ describe("SDK behavior regressions", () => {
     act(() => {
       renderer!.unmount()
     })
+  })
+
+  it("waits for configure before setting subscription status", async () => {
+    let resolveConfigure: ((value: boolean) => void) | undefined
+    mockConfigure.mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        resolveConfigure = resolve
+      }),
+    )
+
+    const pendingSet = useSuperwallStore.getState().setSubscriptionStatus({ status: "INACTIVE" })
+
+    const pendingConfigure = useSuperwallStore.getState().configure("api-key")
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(mockSetSubscriptionStatus).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveConfigure?.(true)
+      await pendingConfigure
+      await pendingSet
+    })
+
+    expect(mockSetSubscriptionStatus).toHaveBeenCalledWith({ status: "INACTIVE" })
+  })
+
+  it("waits for configure before setting integration attributes", async () => {
+    let resolveConfigure: ((value: boolean) => void) | undefined
+    mockConfigure.mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        resolveConfigure = resolve
+      }),
+    )
+
+    const pendingAttributes = useSuperwallStore
+      .getState()
+      .setIntegrationAttributes({ adjustId: "adjust-123" })
+
+    const pendingConfigure = useSuperwallStore.getState().configure("api-key")
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(mockSetIntegrationAttributes).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveConfigure?.(true)
+      await pendingConfigure
+      await pendingAttributes
+    })
+
+    expect(mockSetIntegrationAttributes).toHaveBeenCalledWith({ adjustId: "adjust-123" })
+  })
+
+  it("rejects queued native calls when configure fails", async () => {
+    mockConfigure.mockRejectedValueOnce(new Error("native configure failed"))
+
+    const pendingSet = useSuperwallStore.getState().setSubscriptionStatus({ status: "INACTIVE" })
+
+    const pendingConfigure = useSuperwallStore.getState().configure("api-key")
+
+    await expect(pendingConfigure).resolves.toBeUndefined()
+    await expect(pendingSet).rejects.toThrow("native configure failed")
+    expect(mockSetSubscriptionStatus).not.toHaveBeenCalled()
   })
 
   it("replays buffered log and superwall events once after hooks mount", () => {
@@ -368,10 +453,7 @@ describe("SDK behavior regressions", () => {
     })
 
     expect(matchingDismiss).toHaveBeenCalledTimes(1)
-    expect(matchingDismiss).toHaveBeenCalledWith(
-      { name: "buffered-paywall" },
-      { type: "declined" },
-    )
+    expect(matchingDismiss).toHaveBeenCalledWith({ name: "buffered-paywall" }, { type: "declined" })
     expect(globalDismiss).not.toHaveBeenCalled()
 
     act(() => {

--- a/src/__tests__/sdk.behavior.test.tsx
+++ b/src/__tests__/sdk.behavior.test.tsx
@@ -78,6 +78,8 @@ const {
   __resetSuperwallEventBridgeForTests,
 }: typeof import("../internal/superwallEventBridge") = require("../internal/superwallEventBridge")
 
+const originalConfigure = useSuperwallStore.getState().configure
+
 describe("SDK behavior regressions", () => {
   let consoleErrorSpy: jest.SpyInstance
   let consoleLogSpy: jest.SpyInstance
@@ -94,6 +96,7 @@ describe("SDK behavior regressions", () => {
       configurationError: null,
       user: null,
       subscriptionStatus: { status: "UNKNOWN" },
+      configure: originalConfigure,
     })
   })
 

--- a/src/useSuperwall.ts
+++ b/src/useSuperwall.ts
@@ -14,39 +14,24 @@ import { DefaultSuperwallOptions, type PartialSuperwallOptions } from "./Superwa
 import { filterUndefined } from "./utils/filterUndefined"
 
 const CONFIGURE_WAIT_TIMEOUT_MS = 10_000
-let configurePromise: Promise<void> | null = null
 
 const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 const timeoutError = () =>
   new Error(`Timed out waiting ${CONFIGURE_WAIT_TIMEOUT_MS}ms for Superwall configure to complete.`)
 
-const withConfigureTimeout = (promise: Promise<void>, timeoutMs: number): Promise<void> =>
-  new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(timeoutError())
-    }, timeoutMs)
-
-    promise.then(
-      () => {
-        clearTimeout(timeout)
-        resolve()
-      },
-      (error) => {
-        clearTimeout(timeout)
-        reject(error)
-      },
-    )
-  })
-
+/**
+ * Blocks a native call until Superwall has finished configuring.
+ *
+ * Returns as soon as `isConfigured` flips true, throws if configuration failed
+ * (`configurationError`), or throws after CONFIGURE_WAIT_TIMEOUT_MS if configure
+ * never completes. Waiting is derived purely from store state, so it stays
+ * correct no matter when configure() runs relative to the gated call.
+ */
 async function awaitConfigured(): Promise<void> {
-  if (useSuperwallStore.getState().isConfigured) {
-    return
-  }
-
   const startedAt = Date.now()
 
-  while (!configurePromise) {
+  for (;;) {
     const { isConfigured, configurationError } = useSuperwallStore.getState()
 
     if (isConfigured) {
@@ -62,15 +47,6 @@ async function awaitConfigured(): Promise<void> {
     }
 
     await nextTick()
-  }
-
-  const remainingTimeout = Math.max(0, CONFIGURE_WAIT_TIMEOUT_MS - (Date.now() - startedAt))
-
-  await withConfigureTimeout(configurePromise, remainingTimeout)
-
-  const { isConfigured, configurationError } = useSuperwallStore.getState()
-  if (!isConfigured) {
-    throw new Error(configurationError ?? "Superwall configure did not complete.")
   }
 }
 
@@ -292,7 +268,7 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
   configure: async (apiKey, options) => {
     set({ isLoading: true, configurationError: null })
 
-    const task = (async () => {
+    try {
       const { manualPurchaseManagement, manualPurchaseManagment, ...restOptions } = options || {}
 
       // Support both spellings for backward compatibility
@@ -334,12 +310,6 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
         user: currentUser as UserAttributes,
         subscriptionStatus,
       })
-    })()
-
-    configurePromise = task
-
-    try {
-      await task
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
       set({

--- a/src/useSuperwall.ts
+++ b/src/useSuperwall.ts
@@ -13,6 +13,67 @@ import type {
 import { DefaultSuperwallOptions, type PartialSuperwallOptions } from "./SuperwallOptions"
 import { filterUndefined } from "./utils/filterUndefined"
 
+const CONFIGURE_WAIT_TIMEOUT_MS = 10_000
+let configurePromise: Promise<void> | null = null
+
+const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+const timeoutError = () =>
+  new Error(`Timed out waiting ${CONFIGURE_WAIT_TIMEOUT_MS}ms for Superwall configure to complete.`)
+
+const withConfigureTimeout = (promise: Promise<void>, timeoutMs: number): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(timeoutError())
+    }, timeoutMs)
+
+    promise.then(
+      () => {
+        clearTimeout(timeout)
+        resolve()
+      },
+      (error) => {
+        clearTimeout(timeout)
+        reject(error)
+      },
+    )
+  })
+
+async function awaitConfigured(): Promise<void> {
+  if (useSuperwallStore.getState().isConfigured) {
+    return
+  }
+
+  const startedAt = Date.now()
+
+  while (!configurePromise) {
+    const { isConfigured, configurationError } = useSuperwallStore.getState()
+
+    if (isConfigured) {
+      return
+    }
+
+    if (configurationError) {
+      throw new Error(configurationError)
+    }
+
+    if (Date.now() - startedAt >= CONFIGURE_WAIT_TIMEOUT_MS) {
+      throw timeoutError()
+    }
+
+    await nextTick()
+  }
+
+  const remainingTimeout = Math.max(0, CONFIGURE_WAIT_TIMEOUT_MS - (Date.now() - startedAt))
+
+  await withConfigureTimeout(configurePromise, remainingTimeout)
+
+  const { isConfigured, configurationError } = useSuperwallStore.getState()
+  if (!isConfigured) {
+    throw new Error(configurationError ?? "Superwall configure did not complete.")
+  }
+}
+
 /**
  * @category Models
  * @since 0.0.15
@@ -231,7 +292,7 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
   configure: async (apiKey, options) => {
     set({ isLoading: true, configurationError: null })
 
-    try {
+    const task = (async () => {
       const { manualPurchaseManagement, manualPurchaseManagment, ...restOptions } = options || {}
 
       // Support both spellings for backward compatibility
@@ -273,6 +334,12 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
         user: currentUser as UserAttributes,
         subscriptionStatus,
       })
+    })()
+
+    configurePromise = task
+
+    try {
+      await task
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
       set({
@@ -283,6 +350,7 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
     }
   },
   identify: async (userId, options) => {
+    await awaitConfigured()
     await SuperwallExpoModule.identify(userId, options)
 
     // TODO: Instead of setting users after identify, we should set this based on an event
@@ -296,6 +364,7 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
     set({ user: currentUser as UserAttributes, subscriptionStatus })
   },
   reset: async () => {
+    await awaitConfigured()
     await SuperwallExpoModule.reset()
 
     const currentUser = await SuperwallExpoModule.getUserAttributes()
@@ -304,39 +373,49 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
     set({ user: currentUser as UserAttributes, subscriptionStatus })
   },
   registerPlacement: async (placement, params, handlerId = "default") => {
+    await awaitConfigured()
     await SuperwallExpoModule.registerPlacement(placement, params, handlerId)
   },
   getPresentationResult: async (placement, params) => {
+    await awaitConfigured()
     return SuperwallExpoModule.getPresentationResult(placement, params)
   },
   restorePurchases: async () => {
+    await awaitConfigured()
     return SuperwallExpoModule.restorePurchases()
   },
   dismiss: async () => {
+    await awaitConfigured()
     await SuperwallExpoModule.dismiss()
   },
   preloadAllPaywalls: async () => {
-    SuperwallExpoModule.preloadAllPaywalls()
+    await awaitConfigured()
+    await SuperwallExpoModule.preloadAllPaywalls()
   },
   preloadPaywalls: async (placements) => {
-    SuperwallExpoModule.preloadPaywalls(placements)
+    await awaitConfigured()
+    await SuperwallExpoModule.preloadPaywalls(placements)
   },
   setUserAttributes: async (attrs) => {
+    await awaitConfigured()
     await SuperwallExpoModule.setUserAttributes(filterUndefined(attrs))
 
     const currentUser = await SuperwallExpoModule.getUserAttributes()
     set({ user: currentUser as UserAttributes })
   },
   getUserAttributes: async () => {
+    await awaitConfigured()
     const attributes = await SuperwallExpoModule.getUserAttributes()
     set({ user: attributes as UserAttributes })
     return attributes
   },
   setLogLevel: async (level) => {
-    SuperwallExpoModule.setLogLevel(level)
+    await awaitConfigured()
+    await SuperwallExpoModule.setLogLevel(level)
   },
 
   setIntegrationAttributes: async (attributes) => {
+    await awaitConfigured()
     await SuperwallExpoModule.setIntegrationAttributes(attributes)
 
     const currentUser = await SuperwallExpoModule.getUserAttributes()
@@ -344,17 +423,21 @@ export const useSuperwallStore = create<SuperwallStore>((set, get) => ({
   },
 
   getIntegrationAttributes: async () => {
+    await awaitConfigured()
     return SuperwallExpoModule.getIntegrationAttributes()
   },
 
   setSubscriptionStatus: async (status) => {
+    await awaitConfigured()
     await SuperwallExpoModule.setSubscriptionStatus(status)
   },
   getDeviceAttributes: async () => {
+    await awaitConfigured()
     const attributes = await SuperwallExpoModule.getDeviceAttributes()
     return attributes
   },
   getEntitlements: async () => {
+    await awaitConfigured()
     const entitlements = await SuperwallExpoModule.getEntitlements()
     return entitlements as EntitlementsInfo
   },

--- a/src/useSuperwall.ts
+++ b/src/useSuperwall.ts
@@ -15,39 +15,60 @@ import { filterUndefined } from "./utils/filterUndefined"
 
 const CONFIGURE_WAIT_TIMEOUT_MS = 10_000
 
-const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0))
-
-const timeoutError = () =>
-  new Error(`Timed out waiting ${CONFIGURE_WAIT_TIMEOUT_MS}ms for Superwall configure to complete.`)
-
 /**
  * Blocks a native call until Superwall has finished configuring.
  *
- * Returns as soon as `isConfigured` flips true, throws if configuration failed
- * (`configurationError`), or throws after CONFIGURE_WAIT_TIMEOUT_MS if configure
- * never completes. Waiting is derived purely from store state, so it stays
- * correct no matter when configure() runs relative to the gated call.
+ * Resolves as soon as `isConfigured` flips true, rejects if configuration failed
+ * (`configurationError`), and otherwise rejects after CONFIGURE_WAIT_TIMEOUT_MS.
+ * The timeout clock (re)starts when configure() begins — so a configure() called
+ * late still gets the full window — and the error distinguishes "never called"
+ * from "called but too slow". Subscribes to the store rather than polling.
  */
-async function awaitConfigured(): Promise<void> {
-  const startedAt = Date.now()
+function awaitConfigured(): Promise<void> {
+  const { isConfigured, configurationError } = useSuperwallStore.getState()
+  if (isConfigured) return Promise.resolve()
+  if (configurationError) return Promise.reject(new Error(configurationError))
 
-  for (;;) {
-    const { isConfigured, configurationError } = useSuperwallStore.getState()
+  return new Promise<void>((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout>
 
-    if (isConfigured) {
-      return
+    const settle = (fn: () => void) => {
+      clearTimeout(timer)
+      unsubscribe()
+      fn()
     }
 
-    if (configurationError) {
-      throw new Error(configurationError)
+    // Restart the clock when configure starts so a late configure() gets the full
+    // window instead of inheriting time already spent waiting before it ran.
+    const arm = () => {
+      clearTimeout(timer)
+      timer = setTimeout(() => {
+        const inFlight = useSuperwallStore.getState().isLoading
+        settle(() =>
+          reject(
+            new Error(
+              inFlight
+                ? `Superwall configure did not complete within ${CONFIGURE_WAIT_TIMEOUT_MS}ms.`
+                : `Superwall configure was not called within ${CONFIGURE_WAIT_TIMEOUT_MS}ms. Did you forget to call configure()?`,
+            ),
+          ),
+        )
+      }, CONFIGURE_WAIT_TIMEOUT_MS)
     }
 
-    if (Date.now() - startedAt >= CONFIGURE_WAIT_TIMEOUT_MS) {
-      throw timeoutError()
-    }
+    const unsubscribe = useSuperwallStore.subscribe((state, prev) => {
+      if (state.isConfigured) {
+        settle(resolve)
+      } else if (state.configurationError) {
+        const error = state.configurationError
+        settle(() => reject(new Error(error)))
+      } else if (state.isLoading && !prev.isLoading) {
+        arm()
+      }
+    })
 
-    await nextTick()
-  }
+    arm()
+  })
 }
 
 /**


### PR DESCRIPTION
Awaits in async methods to ensure config was resolve before running

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the previous `awaitConfigured` polling loop with a Zustand `subscribe`-based approach and adds `await awaitConfigured()` guards to all public SDK actions that require configuration. The re-arm-on-`isLoading` mechanism ensures a late `configure()` call still gets the full timeout window, and error messages distinguish "configure never called" from "configure timed out."

- **`awaitConfigured` rewrite (`useSuperwall.ts`)**: Switches from `setTimeout(0)` polling to a single Zustand subscription; arms/re-arms a 10-second deadline only when `configure()` begins (`isLoading` false→true transition), and cleans up cleanly on resolve, reject, or timeout.
- **Gating added across all public actions**: Every action that requires a live SDK (`identify`, `reset`, `registerPlacement`, `setSubscriptionStatus`, `setIntegrationAttributes`, etc.) now awaits `awaitConfigured()` before making native calls.
- **New regression tests**: Cover the "waits before setting subscription status," "waits before setting integration attributes," and "rejects queued callers when configure fails" scenarios.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the subscribe-based gate is correctly bounded, settles exactly once, and covers all gated public actions.

The awaitConfigured rewrite is logically sound: the subscriber fires exactly once (settle() calls unsubscribe() and clearTimeout()), the timer always fires within 10s so no promise can leak, and the re-arm on the isLoading false→true transition ensures a late configure() still gets a full window. All public SDK actions that require a live SDK are now gated, and the three new regression tests validate the main ordering and failure scenarios.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/useSuperwall.ts | Core change: replaces polling-based awaitConfigured with a Zustand subscribe approach and gates all public SDK actions. Logic is correct — subscriber settles exactly once, timer is always bounded, and error messages distinguish the "never called" vs "timed out" cases. |
| src/__tests__/sdk.behavior.test.tsx | Adds mocks for configure, getUserAttributes, getSubscriptionStatus, setSubscriptionStatus, and setIntegrationAttributes; adds three new tests covering the happy-path ordering guarantee and the configure-failure rejection path. Tests are structurally sound. |
| .changeset/fine-cows-eat.md | Patch-level changeset entry describing the configure-await fix — correct classification. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix review comments"](https://github.com/superwall/expo-superwall/commit/682e0cc940dbf5172c0bd7b8d7cfe1f3a94e4410) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34950888)</sub>

<!-- /greptile_comment -->