### PR TITLE
fix: add shouldShowWebPurchaseConfirmationAlert to PaywallOptions in compat layer

### DIFF
--- a/src/compat/lib/PaywallOptions.ts
+++ b/src/compat/lib/PaywallOptions.ts
@@ -52,6 +52,7 @@ export class PaywallOptions {
   shouldPreload = false
   automaticallyDismiss = true
   transactionBackgroundView: TransactionBackgroundView = TransactionBackgroundView.spinner
+  shouldShowWebPurchaseConfirmationAlert = false
   onBackPressed?: (paywallInfo: PaywallInfo) => boolean
 
   constructor(init?: Partial<PaywallOptions>) {
@@ -64,6 +65,9 @@ export class PaywallOptions {
       }
       if (init.shouldPreload !== undefined) {
         this.shouldPreload = init.shouldPreload
+      }
+      if (init.shouldShowWebPurchaseConfirmationAlert !== undefined) {
+        this.shouldShowWebPurchaseConfirmationAlert = init.shouldShowWebPurchaseConfirmationAlert
       }
       if (init.automaticallyDismiss !== undefined) {
         this.automaticallyDismiss = init.automaticallyDismiss
@@ -92,6 +96,7 @@ export class PaywallOptions {
       shouldPreload: this.shouldPreload,
       automaticallyDismiss: this.automaticallyDismiss,
       transactionBackgroundView: this.transactionBackgroundView,
+      shouldShowWebPurchaseConfirmationAlert: this.shouldShowWebPurchaseConfirmationAlert,
     })
   }
 }


### PR DESCRIPTION
### Summary 
This fixes a bug causing Paywall Options to not get applied from `Superwall.configure` when using `'expo-superwall/compat'` on iOS. I did not test on Android, so I'm not sure if it happens there as well.

I discovered this bug when trying to disable preloading. `shouldPreload` was not being respected. After this fix, it was working.

### The bug, with example code

import from compat:
```ts
import Superwall from 'expo-superwall/compat'
```

init with PaywallOptions:
```ts
  Superwall.configure({
      apiKey,
      purchaseController,
      options: { paywalls: { shouldPreload: false } },
    })
```

Expected behavior;
- shouldPreload option gets applied (no preload happening based on profiler)

Observed behavior:
- shouldPreload option gets ignored (I can see preload happening in profiler)

### The problem

before, my understanding is:
- shouldShowWebPurchaseConfirmationAlert was missing in PaywallOptions (`src/compat/lib/PaywallOptions.ts`)
- so in the native layer, validation failed on PaywallOptions since it is missing that field
  -  `PaywallOptions.fromJson` in `ios/Json/PaywallOptions+Json.swift` guards includes `let shouldShowWebPurchaseConfirmationAlert = dictionary["shouldShowWebPurchaseConfirmationAlert"] as? Bool`
- so `PaywallOptions.fromJson` guard fails and returns `nil`
- that caused no options passed to native

by adding shouldShowWebPurchaseConfirmationAlert, validation passes and all options should get applied. However, I only tested the shouldPreload option, not other PaywallOptions

### Testing

I tested this fix on `expo-superwall` verison 1.0.9 and 1.1.4 

I've tested only on iOS and confirmed the fix. Given the small diff I assume this would work fine on android as well, but I haven't tested there yet.

### AI usage disclaimer
- I discovered the problem in manual testing of our app, but the investigation and root cause of the bug (why are options not being applied?) was primarily done with AI (Cursor + Opus). 
  - I read through the related code and the explanation and fix makes sense to me.
  - My testing confirmed it fixed the issue.
- No AI used in writing this PR description

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in the `expo-superwall/compat` layer where all `PaywallOptions` passed to `Superwall.configure` were silently ignored on iOS. The root cause was that `shouldShowWebPurchaseConfirmationAlert` was absent from the compat layer's `toJson()` output, causing the Swift `guard let` in `PaywallOptions+Json.swift` to return `nil` and discard every option.

- Adds `shouldShowWebPurchaseConfirmationAlert` to the compat `PaywallOptions` class property (default `false`), constructor initialisation, and `toJson()` serialisation — making the field match what the iOS native parser requires.
- Android is unaffected: `SuperwallOptions.kt` already notes this field is iOS-only and uses lenient optional casting rather than a hard guard.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix is minimal, targeted, and directly addresses the root cause of options being silently dropped on iOS.

The change correctly unblocks the iOS native guard by adding the missing field to the compat serialiser. The only open question is whether defaulting `shouldShowWebPurchaseConfirmationAlert` to `false` (matching the non-compat layer but diverging from the native SDK's `true`) is intentional for web checkout users — worth a quick confirm before merging.

src/compat/lib/PaywallOptions.ts — specifically the default value of `shouldShowWebPurchaseConfirmationAlert`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/compat/lib/PaywallOptions.ts | Adds `shouldShowWebPurchaseConfirmationAlert` to the compat-layer PaywallOptions class (property, constructor, and toJson), fixing the iOS guard-let failure that silently dropped all paywall options. Default is `false`, which differs from the native iOS SDK default of `true`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as App (compat layer)
    participant TS as PaywallOptions.toJson()
    participant Native as iOS PaywallOptions+Json.swift

    Note over App,Native: Before fix
    App->>TS: "configure({ paywalls: { shouldPreload: false } })"
    TS-->>Native: "{ isHapticFeedbackEnabled, shouldPreload, ... }<br/>(missing shouldShowWebPurchaseConfirmationAlert)"
    Native-->>Native: guard let ... shouldShowWebPurchaseConfirmationAlert ... else return nil
    Native-->>App: nil — no options applied, native defaults used

    Note over App,Native: After fix
    App->>TS: "configure({ paywalls: { shouldPreload: false } })"
    TS-->>Native: "{ isHapticFeedbackEnabled, shouldPreload, ..., shouldShowWebPurchaseConfirmationAlert: false }"
    Native-->>Native: guard let succeeds
    Native-->>App: PaywallOptions applied ✓
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/compat/lib/PaywallOptions.ts:55
**Default value differs from native iOS SDK default**

The native `PaywallOptions.swift` declares `shouldShowWebPurchaseConfirmationAlert = true`, but this compat layer defaults it to `false`. Because `toJson()` always serialises the value, every compat user who has not explicitly set this option will now have the confirmation alert **disabled** after this fix — even though, before this fix, the native default (`true`) was in effect (since `fromJson` returned `nil` and no custom options were applied).

The non-compat `src/SuperwallOptions.ts` also defaults to `false`, which suggests this may be intentional project-wide policy, but it's worth confirming the intended UX for users with web checkout enabled.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add shouldShowWebPurchaseConfirmati..."](https://github.com/superwall/expo-superwall/commit/2a2053cc72f971f897733284acf43b4fda6ac257) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36015695)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->