### PR TITLE
Fix purchase events dropped on cold start with custom purchase controller

### DIFF
--- a/.changeset/heavy-spoons-shout.md
+++ b/.changeset/heavy-spoons-shout.md
@@ -1,0 +1,5 @@
+---
+"expo-superwall": patch
+---
+
+Fix purchase events being dropped on cold start when using a custom purchase controller, which left the paywall spinner stuck forever. The native module emitted events through a single static reference that was overwritten by every module instance, so when more than one app context exists (e.g. expo-dev-client's launcher plus the app) the reference could point at an instance whose JS runtime never subscribed and `onPurchase`/`onPurchaseRestore` were silently dropped. Native events are now emitted to every live module instance (tracked weakly) instead of only the most recently created one.

--- a/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
@@ -36,12 +36,25 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.runBlocking
 import android.util.Log
+import java.util.Collections
+import java.util.WeakHashMap
 import java.util.concurrent.CompletableFuture
 
 class SuperwallExpoModule : Module() {
 
   companion object {
     var instance: SuperwallExpoModule? = null
+    private val instances = Collections.newSetFromMap(WeakHashMap<SuperwallExpoModule, Boolean>())
+
+    // Events must reach every live module instance. More than one app context can
+    // exist at once (e.g. expo-dev-client's launcher plus the app), and `instance`
+    // may point at a module whose JS runtime never subscribed - sending only
+    // through it silently drops events like `onPurchase`, leaving the native
+    // purchase future incomplete forever.
+    fun emitEvent(name: String, body: Map<String, Any?>?) {
+      val liveInstances = synchronized(instances) { instances.toList() }
+      liveInstances.forEach { it.sendEvent(name, body ?: emptyMap()) }
+    }
   }
 
   val scope = CoroutineScope(Dispatchers.Main)
@@ -50,10 +63,7 @@ class SuperwallExpoModule : Module() {
 
   init {
     instance = this
-  }
-
-  fun emitEvent(name: String, body: Map<String, Any?>?) {
-    SuperwallExpoModule.instance?.sendEvent(name, body?:emptyMap())
+    synchronized(instances) { instances.add(this) }
   }
 
   private val onPaywallPresent = "onPaywallPresent"

--- a/android/src/main/java/expo/modules/superwallexpo/bridges/PurchaseControllerBridge.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/bridges/PurchaseControllerBridge.kt
@@ -41,7 +41,7 @@ class PurchaseControllerBridge(): PurchaseController {
             "offerId" to offerId
         )
         
-        SuperwallExpoModule.instance?.emitEvent(
+        SuperwallExpoModule.emitEvent(
             "onPurchase",
             productData
         )
@@ -52,7 +52,7 @@ class PurchaseControllerBridge(): PurchaseController {
     override suspend fun restorePurchases(): RestorationResult {
         restorePromise = CompletableFuture()
 
-        SuperwallExpoModule.instance?.emitEvent("onPurchaseRestore", null)
+        SuperwallExpoModule.emitEvent("onPurchaseRestore", null)
 
         return restorePromise!!.await()
     }

--- a/android/src/main/java/expo/modules/superwallexpo/bridges/SuperwallDelegateBridge.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/bridges/SuperwallDelegateBridge.kt
@@ -95,7 +95,7 @@ class SuperwallDelegateBridge : SuperwallDelegate {
   }
 
   private fun sendEvent(name: String, body: Map<String, Any?>) {
-    SuperwallExpoModule.instance?.emitEvent(name, body)
+    SuperwallExpoModule.emitEvent(name, body)
   }
 
   override fun willRedeemLink() {

--- a/ios/SuperwallExpoModule.swift
+++ b/ios/SuperwallExpoModule.swift
@@ -19,6 +19,8 @@ private final class AtomicFlag {
 
 public class SuperwallExpoModule: Module {
   public static var shared: SuperwallExpoModule?
+  private static let instancesLock = NSLock()
+  private static let instances = NSHashTable<SuperwallExpoModule>.weakObjects()
 
   private let purchaseController = PurchaseControllerBridge.shared
   private var delegate: SuperwallDelegateBridge?
@@ -55,10 +57,23 @@ public class SuperwallExpoModule: Module {
   public required init(appContext: AppContext) {
     super.init(appContext: appContext)
     SuperwallExpoModule.shared = self
+    SuperwallExpoModule.instancesLock.lock()
+    SuperwallExpoModule.instances.add(self)
+    SuperwallExpoModule.instancesLock.unlock()
   }
 
+  // Events must reach every live module instance. More than one app context can
+  // exist at once (e.g. expo-dev-client's launcher plus the app), and `shared`
+  // may point at an instance whose JS runtime never subscribed - sending only
+  // through it silently drops events like `onPurchase`, leaving the native
+  // purchase continuation suspended forever.
   public static func emitEvent(_ name: String, _ data: [String: Any]?) {
-    SuperwallExpoModule.shared?.sendEvent(name, data ?? [:])
+    instancesLock.lock()
+    let liveInstances = instances.allObjects
+    instancesLock.unlock()
+    for instance in liveInstances {
+      instance.sendEvent(name, data ?? [:])
+    }
   }
 
   public func definition() -> ModuleDefinition {


### PR DESCRIPTION
Fixes #157

## Problem

With a `CustomPurchaseControllerProvider`, tapping purchase on a cold/first launch can leave the paywall spinner stuck forever: the native side emits `onPurchase` and suspends (`withCheckedContinuation` on iOS / `CompletableFuture` on Android, neither with a timeout) waiting for `didPurchase` — but the event never reaches the JS handler. Full root-cause analysis with native logs in #157 (comment).

The native module emits events through a single static reference (`SuperwallExpoModule.shared` on iOS / `.instance` on Android) that is overwritten by every module instance created. More than one app context can exist on first launch (e.g. expo-dev-client's launcher plus the app), so the static reference can point at an instance whose JS runtime never subscribed — `sendEvent` is then a silent no-op and the purchase event is dropped, leaving the native continuation suspended forever.

## Change

`emitEvent` now broadcasts to every live module instance (tracked weakly via `NSHashTable` / `WeakHashMap`) instead of only the most recently created one. Expo's `sendEvent` is a no-op on any instance whose JS runtime has no listener for the event, so in a normal topology only the runtime that actually mounted the purchase controller acts on it.

## Verification

Reproduced the infinite spinner reliably on fresh installs in a real RevenueCat purchase-controller integration; with this fix `onPurchase` reaches the JS controller on the very first launch and the payment sheet presents.

(Note: I couldn't run the unit suite from a clean checkout — `jest`/`react` aren't declared as dev deps, so `yarn install && yarn test` fails on `main` too — so this PR keeps the JS bridge untouched and is native-only.)
