### PR TITLE
[SW-5639] Add embedded PaywallView support

### DIFF
--- a/.changeset/inline-paywalls.md
+++ b/.changeset/inline-paywalls.md
@@ -1,0 +1,5 @@
+---
+"expo-superwall": minor
+---
+
+Add a native `PaywallView` component for inline, overlay, and React Native modal layouts, including declarative loading, skipped, error, and dismissed fallbacks.

--- a/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoModule.kt
@@ -127,6 +127,29 @@ class SuperwallExpoModule : Module() {
       didRedeemLink
     )
 
+    View(SuperwallExpoPaywallView::class) {
+      Name("PaywallView")
+      Events(
+        "onPaywallLoadStart",
+        "onPaywallPresent",
+        "onPaywallDismiss",
+        "onPaywallSkip",
+        "onPaywallError",
+      )
+      Prop("placement") { view: SuperwallExpoPaywallView, placement: String ->
+        view.setPlacement(placement)
+      }
+      Prop("params") { view: SuperwallExpoPaywallView, params: Map<String, Any>? ->
+        view.setParams(params)
+      }
+      OnViewDidUpdateProps { view: SuperwallExpoPaywallView ->
+        view.loadPaywallIfNeeded()
+      }
+      OnViewDestroys { view: SuperwallExpoPaywallView ->
+        view.destroy()
+      }
+    }
+
     AsyncFunction("identify") { userId: String, options: Map<String, Any>?, promise: Promise ->
       scope.launch {
         try {
@@ -297,7 +320,6 @@ class SuperwallExpoModule : Module() {
         promise.resolve(null)
       }
     }
-    
 
     AsyncFunction("getAssignments") { promise: Promise ->
         Superwall.instance.getAssignments()

--- a/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoPaywallView.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoPaywallView.kt
@@ -1,0 +1,176 @@
+package expo.modules.superwallexpo
+
+import android.content.Context
+import android.view.ViewGroup
+import com.superwall.sdk.paywall.presentation.get_paywall.builder.PaywallBuilder
+import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason
+import com.superwall.sdk.paywall.presentation.internal.state.PaywallResult
+import com.superwall.sdk.paywall.presentation.internal.state.PaywallSkippedReason
+import com.superwall.sdk.paywall.view.PaywallView
+import com.superwall.sdk.paywall.view.delegate.PaywallViewCallback
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.views.ExpoView
+import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.superwallexpo.json.toJson
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+
+/** A React Native host view that owns one SDK PaywallView at a time. */
+class SuperwallExpoPaywallView(
+  context: Context,
+  appContext: AppContext,
+) : ExpoView(context, appContext) {
+  override val shouldUseAndroidLayout = true
+
+  val onPaywallLoadStart by EventDispatcher<Map<String, Any>>()
+  val onPaywallPresent by EventDispatcher<Map<String, Any>>()
+  val onPaywallDismiss by EventDispatcher<Map<String, Any>>()
+  val onPaywallSkip by EventDispatcher<Map<String, Any>>()
+  val onPaywallError by EventDispatcher<Map<String, Any>>()
+
+  private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+  private var placement: String? = null
+  private var params: Map<String, Any>? = null
+  private var loadedPlacement: String? = null
+  private var loadedParams: Map<String, Any>? = null
+  private var loadGeneration = 0
+  private var paywallView: PaywallView? = null
+
+  private val delegate =
+    object : PaywallViewCallback {
+      override fun onFinished(
+        paywall: PaywallView,
+        result: PaywallResult,
+        shouldDismiss: Boolean,
+      ) {
+        if (paywall !== paywallView) return
+
+        onPaywallDismiss(
+          mapOf(
+            "paywallInfo" to paywall.info.toJson(),
+            "result" to result.toJson(),
+            "shouldDismiss" to shouldDismiss,
+          ),
+        )
+
+        if (shouldDismiss) {
+          releasePaywall()
+        }
+      }
+    }
+
+  fun setPlacement(placement: String) {
+    this.placement = placement
+  }
+
+  fun setParams(params: Map<String, Any>?) {
+    this.params = params
+  }
+
+  fun loadPaywallIfNeeded() {
+    val placement = placement ?: return
+    if (placement.isEmpty() || !isAttachedToWindow) return
+    if (placement == loadedPlacement && params == loadedParams) return
+
+    loadedPlacement = placement
+    loadedParams = params?.toMap()
+    loadGeneration += 1
+    val generation = loadGeneration
+    releasePaywall()
+    onPaywallLoadStart(emptyMap())
+
+    val activity = appContext.currentActivity
+    if (activity == null) {
+      onPaywallError(mapOf("message" to "No current Activity is available to load the paywall."))
+      return
+    }
+
+    PaywallBuilder(placement)
+      .params(params)
+      .delegate(delegate)
+      .activity(activity)
+      .build(
+        onSuccess = { paywall ->
+          if (generation != loadGeneration || !isAttachedToWindow) {
+            if (paywall.parent == null) {
+              cleanupPaywall(paywall)
+            }
+            return@build
+          }
+          if (paywall.parent != null) {
+            onPaywallError(
+              mapOf(
+                "message" to
+                  "The retrieved paywall is already attached to another view. " +
+                  "Use a different placement for each mounted PaywallView.",
+              ),
+            )
+            return@build
+          }
+
+          paywallView = paywall
+          addView(
+            paywall,
+            LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT),
+          )
+          paywall.onViewCreated()
+          onPaywallPresent(mapOf("paywallInfo" to paywall.info.toJson()))
+        },
+        onError = { error ->
+          if (generation != loadGeneration) return@build
+          if (error is PaywallSkippedReason) {
+            onPaywallSkip(mapOf("reason" to error.toJson()))
+          } else {
+            val message =
+              if (error is PaywallPresentationRequestStatusReason) {
+                error.info
+              } else {
+                error.localizedMessage ?: error.toString()
+              }
+            onPaywallError(mapOf("message" to message))
+          }
+        },
+      )
+  }
+
+  fun destroy() {
+    loadGeneration += 1
+    loadedPlacement = null
+    loadedParams = null
+    releasePaywall()
+    mainScope.cancel()
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    loadPaywallIfNeeded()
+  }
+
+  override fun onDetachedFromWindow() {
+    loadGeneration += 1
+    loadedPlacement = null
+    loadedParams = null
+    releasePaywall()
+    super.onDetachedFromWindow()
+  }
+
+  private fun releasePaywall() {
+    val paywall = paywallView
+    paywallView = null
+    if (paywall == null) return
+    removeView(paywall)
+    cleanupPaywall(paywall)
+  }
+
+  private fun cleanupPaywall(paywall: PaywallView) {
+    paywall.beforeOnDestroy(forceCleanup = true)
+    paywall.encapsulatingActivity = null
+    mainScope.launch {
+      paywall.destroyed(forceCleanup = true)
+      paywall.cleanup()
+    }
+  }
+}

--- a/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoPaywallView.kt
+++ b/android/src/main/java/expo/modules/superwallexpo/SuperwallExpoPaywallView.kt
@@ -1,6 +1,7 @@
 package expo.modules.superwallexpo
 
 import android.content.Context
+import android.content.res.Configuration
 import android.view.ViewGroup
 import com.superwall.sdk.paywall.presentation.get_paywall.builder.PaywallBuilder
 import com.superwall.sdk.paywall.presentation.internal.PaywallPresentationRequestStatusReason
@@ -9,16 +10,26 @@ import com.superwall.sdk.paywall.presentation.internal.state.PaywallSkippedReaso
 import com.superwall.sdk.paywall.view.PaywallView
 import com.superwall.sdk.paywall.view.delegate.PaywallViewCallback
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.views.ExpoView
 import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.kotlin.views.ExpoView
 import expo.modules.superwallexpo.json.toJson
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
-/** A React Native host view that owns one SDK PaywallView at a time. */
+/**
+ * A React Native host view that owns one SDK PaywallView at a time.
+ *
+ * PaywallView instances are cached and shared by the SDK (keyed by paywall, not placement),
+ * so this host never destroys a paywall it merely stops showing: reloads and stale results
+ * detach only, and the SDK revives the cached instance on the next acquisition. The full
+ * destructive teardown runs only when a presentation genuinely ends (dismissal or unmount),
+ * and any rebuild waits for it to finish because the SDK cache can hand the same instance
+ * straight back.
+ */
 class SuperwallExpoPaywallView(
   context: Context,
   appContext: AppContext,
@@ -31,13 +42,20 @@ class SuperwallExpoPaywallView(
   val onPaywallSkip by EventDispatcher<Map<String, Any>>()
   val onPaywallError by EventDispatcher<Map<String, Any>>()
 
-  private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+  private val loadScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+  // Teardown must survive destroy(): cancelling destroyed()/cleanup() mid-flight would
+  // leave the shared cached PaywallView half torn down.
+  private val teardownScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+  private var teardownJob: Job? = null
+
   private var placement: String? = null
   private var params: Map<String, Any>? = null
   private var loadedPlacement: String? = null
   private var loadedParams: Map<String, Any>? = null
   private var loadGeneration = 0
   private var paywallView: PaywallView? = null
+  private var lastUiMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
 
   private val delegate =
     object : PaywallViewCallback {
@@ -57,7 +75,7 @@ class SuperwallExpoPaywallView(
         )
 
         if (shouldDismiss) {
-          releasePaywall()
+          teardownPaywall()
         }
       }
     }
@@ -75,32 +93,45 @@ class SuperwallExpoPaywallView(
     if (placement.isEmpty() || !isAttachedToWindow) return
     if (placement == loadedPlacement && params == loadedParams) return
 
+    val paramsSnapshot = params?.toMap()
     loadedPlacement = placement
-    loadedParams = params?.toMap()
+    loadedParams = paramsSnapshot
     loadGeneration += 1
     val generation = loadGeneration
-    releasePaywall()
+    detachPaywall()
     onPaywallLoadStart(emptyMap())
 
     val activity = appContext.currentActivity
     if (activity == null) {
+      clearLoadedConfig()
       onPaywallError(mapOf("message" to "No current Activity is available to load the paywall."))
       return
     }
 
-    PaywallBuilder(placement)
-      .params(params)
-      .delegate(delegate)
-      .activity(activity)
-      .build(
+    loadScope.launch {
+      // Never acquire from the SDK cache while a previous instance is still tearing
+      // down: getPaywall can return that same instance.
+      teardownJob?.join()
+      if (generation != loadGeneration) return@launch
+
+      val result =
+        PaywallBuilder(placement)
+          .params(paramsSnapshot)
+          .delegate(delegate)
+          .activity(activity)
+          .build()
+
+      if (generation != loadGeneration || !isAttachedToWindow) {
+        // Stale result. The view belongs to the SDK cache; leave it for the next
+        // acquisition. If this host is merely detached, allow a reattach to retry.
+        if (generation == loadGeneration) clearLoadedConfig()
+        return@launch
+      }
+
+      result.fold(
         onSuccess = { paywall ->
-          if (generation != loadGeneration || !isAttachedToWindow) {
-            if (paywall.parent == null) {
-              cleanupPaywall(paywall)
-            }
-            return@build
-          }
           if (paywall.parent != null) {
+            clearLoadedConfig()
             onPaywallError(
               mapOf(
                 "message" to
@@ -108,7 +139,7 @@ class SuperwallExpoPaywallView(
                   "Use a different placement for each mounted PaywallView.",
               ),
             )
-            return@build
+            return@fold
           }
 
           paywallView = paywall
@@ -119,11 +150,11 @@ class SuperwallExpoPaywallView(
           paywall.onViewCreated()
           onPaywallPresent(mapOf("paywallInfo" to paywall.info.toJson()))
         },
-        onError = { error ->
-          if (generation != loadGeneration) return@build
+        onFailure = { error ->
           if (error is PaywallSkippedReason) {
             onPaywallSkip(mapOf("reason" to error.toJson()))
           } else {
+            clearLoadedConfig()
             val message =
               if (error is PaywallPresentationRequestStatusReason) {
                 error.info
@@ -134,14 +165,14 @@ class SuperwallExpoPaywallView(
           }
         },
       )
+    }
   }
 
   fun destroy() {
     loadGeneration += 1
-    loadedPlacement = null
-    loadedParams = null
-    releasePaywall()
-    mainScope.cancel()
+    clearLoadedConfig()
+    teardownPaywall()
+    loadScope.cancel()
   }
 
   override fun onAttachedToWindow() {
@@ -149,28 +180,42 @@ class SuperwallExpoPaywallView(
     loadPaywallIfNeeded()
   }
 
-  override fun onDetachedFromWindow() {
-    loadGeneration += 1
+  override fun onConfigurationChanged(newConfig: Configuration?) {
+    super.onConfigurationChanged(newConfig)
+    val uiMode = (newConfig ?: resources.configuration).uiMode and Configuration.UI_MODE_NIGHT_MASK
+    if (uiMode != lastUiMode) {
+      lastUiMode = uiMode
+      paywallView?.takeIf { it.state.isPresented }?.onThemeChanged()
+    }
+  }
+
+  private fun clearLoadedConfig() {
     loadedPlacement = null
     loadedParams = null
-    releasePaywall()
-    super.onDetachedFromWindow()
   }
 
-  private fun releasePaywall() {
-    val paywall = paywallView
+  /**
+   * Stops showing the current paywall without destroying it. Used when swapping
+   * configuration: the SDK cache owns the instance and resets its transient
+   * presentation state when it is next acquired.
+   */
+  private fun detachPaywall() {
+    val paywall = paywallView ?: return
     paywallView = null
-    if (paywall == null) return
     removeView(paywall)
-    cleanupPaywall(paywall)
   }
 
-  private fun cleanupPaywall(paywall: PaywallView) {
+  /** Ends the presentation for real: dismissal or host unmount. */
+  private fun teardownPaywall() {
+    val paywall = paywallView ?: return
+    paywallView = null
+    removeView(paywall)
     paywall.beforeOnDestroy(forceCleanup = true)
     paywall.encapsulatingActivity = null
-    mainScope.launch {
-      paywall.destroyed(forceCleanup = true)
-      paywall.cleanup()
-    }
+    teardownJob =
+      teardownScope.launch {
+        paywall.destroyed(forceCleanup = true)
+        paywall.cleanup()
+      }
   }
 }

--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -48,6 +48,13 @@ export default function RootLayout() {
           headerShown: true
         }}
       />
+      <Stack.Screen
+        name="article-paywall"
+        options={{
+          title: 'Inline Article Paywall',
+          headerShown: true
+        }}
+      />
     </Stack>
   );
 }

--- a/example/app/article-paywall.tsx
+++ b/example/app/article-paywall.tsx
@@ -1,0 +1,449 @@
+import { BlurView } from "expo-blur"
+import type { PresentationResult } from "expo-superwall"
+import {
+  PaywallView,
+  PresentationResultPaywall,
+  SuperwallLoaded,
+  SuperwallLoading,
+  SuperwallProvider,
+  useSuperwall,
+  useSuperwallEvents,
+} from "expo-superwall"
+import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  ActivityIndicator,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native"
+
+const IOS_API_KEY = "pk_e361c8a9662281f4249f2fa11d1a63854615fa80e15e7a4d"
+const ANDROID_API_KEY = "pk_6d16c4c892b1e792490ab8bfe831f1ad96e7c18aee7a5257"
+
+// These platform-specific placements match the campaigns configured for the checked-in
+// example API keys. In your app, use the placement names from your own dashboard.
+const INLINE_PLACEMENT = Platform.select({ ios: "test", android: "campaign_trigger" }) ?? "test"
+const ALL_PLANS_PLACEMENT = Platform.select({ ios: "pro", android: "premium" }) ?? "pro"
+const SHOW_ALL_PLANS_ACTION = "showFromInline"
+
+type EmbedMode = "inline" | "overlay"
+type GateDecision = "checking" | "gated" | "unlocked"
+
+function presentationResultType(result: PresentationResult): string {
+  const nativeType = (result as PresentationResult & { type?: unknown }).type
+  if (typeof nativeType === "string") return nativeType
+  return result.constructor.name.replace("PresentationResult", "")
+}
+
+function ArticlePaywallDemo() {
+  const [mode, setMode] = useState<EmbedMode>("inline")
+  const [gateDecision, setGateDecision] = useState<GateDecision>("checking")
+  const [gateReason, setGateReason] = useState("Checking the remote placement…")
+  const [inlineStatus, setInlineStatus] = useState("Waiting for the remote decision…")
+  const [fullScreenPlacement, setFullScreenPlacement] = useState<string | null>(null)
+  const [fullScreenStatus, setFullScreenStatus] = useState("idle")
+  const [fullScreenError, setFullScreenError] = useState<string | null>(null)
+  const evaluationGeneration = useRef(0)
+
+  const getPresentationResult = useSuperwall((store) => store.getPresentationResult)
+
+  const refreshGateDecision = useCallback(async () => {
+    evaluationGeneration.current += 1
+    const generation = evaluationGeneration.current
+    setGateDecision("checking")
+    setGateReason("Checking the remote placement…")
+
+    try {
+      const result = await getPresentationResult(INLINE_PLACEMENT)
+      if (generation !== evaluationGeneration.current) return
+
+      const resultType = presentationResultType(result)
+      const shouldPresent = result instanceof PresentationResultPaywall || resultType === "Paywall"
+
+      setGateDecision(shouldPresent ? "gated" : "unlocked")
+      setGateReason(`Presentation result: ${resultType}`)
+      setInlineStatus(shouldPresent ? "Loading inline paywall…" : "Article unlocked remotely")
+    } catch (error) {
+      if (generation !== evaluationGeneration.current) return
+
+      const message = error instanceof Error ? error.message : String(error)
+      // If a remote decision cannot provide a paywall, do not strand the reader behind a blur.
+      setGateDecision("unlocked")
+      setGateReason(`Presentation result failed open: ${message}`)
+      setInlineStatus("Article unlocked because the remote decision failed")
+    }
+  }, [getPresentationResult])
+
+  useEffect(() => {
+    void refreshGateDecision()
+    return () => {
+      evaluationGeneration.current += 1
+    }
+  }, [refreshGateDecision])
+
+  const presentFullScreen = (placement: string) => {
+    setFullScreenError(null)
+    setFullScreenStatus("loading")
+    setFullScreenPlacement(placement)
+  }
+
+  const previewFullScreen = () => {
+    // A native paywall view/controller is single-use. Keep the embedded paywall mounted and
+    // retrieve a separate placement for the full-screen presentation, matching the production flow.
+    presentFullScreen(ALL_PLANS_PLACEMENT)
+  }
+
+  useSuperwallEvents({
+    onCustomPaywallAction: (name) => {
+      if (name === SHOW_ALL_PLANS_ACTION) {
+        presentFullScreen(ALL_PLANS_PLACEMENT)
+      }
+    },
+  })
+
+  const paywall = (
+    <PaywallView
+      placement={INLINE_PLACEMENT}
+      style={[styles.paywallFrame, mode === "overlay" && styles.overlayFrame]}
+      renderFallback={(state) => {
+        if (state.status === "loading") {
+          return (
+            <View pointerEvents="none" style={styles.paywallPlaceholder}>
+              <ActivityIndicator color="#6d5dfc" />
+              <Text style={styles.statusText}>{inlineStatus}</Text>
+            </View>
+          )
+        }
+
+        if (state.status === "error") {
+          return (
+            <View style={styles.paywallPlaceholder}>
+              <Text style={styles.statusText}>Unable to load this offer.</Text>
+              <Text style={styles.errorText}>{state.error}</Text>
+            </View>
+          )
+        }
+
+        // A skipped or dismissed inline paywall leaves no empty native view behind.
+        return null
+      }}
+      onPresent={(info) => setInlineStatus(`Loaded ${info.name}`)}
+      onDismiss={(_, result) => {
+        setInlineStatus(`Inline result: ${result.type}`)
+        if (result.type === "purchased" || result.type === "restored") {
+          void refreshGateDecision()
+        }
+      }}
+      onSkip={(reason) => {
+        setInlineStatus(`Inline skipped: ${reason.type}`)
+        setGateDecision("unlocked")
+      }}
+      onError={(error) => setInlineStatus(`Inline error: ${error}`)}
+    />
+  )
+
+  return (
+    <View style={styles.screen}>
+      <ScrollView contentContainerStyle={styles.article}>
+        <Text style={styles.eyebrow}>THE SUPERWALL JOURNAL</Text>
+        <Text style={styles.title}>How thoughtful paywalls can keep readers in the story</Text>
+        <Text style={styles.byline}>By Superwall · 8 min read</Text>
+
+        <View style={styles.modePicker}>
+          {(["inline", "overlay"] as const).map((value) => (
+            <Pressable
+              accessibilityRole="button"
+              key={value}
+              onPress={() => setMode(value)}
+              style={[styles.modeButton, mode === value && styles.modeButtonSelected]}
+            >
+              <Text style={[styles.modeLabel, mode === value && styles.modeLabelSelected]}>
+                {value === "inline" ? "Inline" : "Overlay"}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+        <Text style={styles.gateStatus}>{gateReason}</Text>
+
+        <Text style={styles.lede}>
+          A subscription prompt does not have to interrupt the reading experience. An embedded
+          paywall can sit naturally between editorial sections while still giving readers a clear
+          path to every available plan.
+        </Text>
+        <Text style={styles.paragraph}>
+          The first section remains readable, preserving context and trust. Superwall retrieves the
+          paywall selected for the placement and mounts its native view directly inside this React
+          Native layout.
+        </Text>
+
+        {mode === "inline" && gateDecision === "gated" && paywall}
+
+        <View style={styles.gatedSection}>
+          <Text style={styles.sectionTitle}>Designing the moment of conversion</Text>
+          <Text style={styles.paragraph}>
+            The strongest subscription moments feel like part of the product. They explain what
+            comes next, connect the offer to the reader’s intent, and make alternate plans easy to
+            discover without losing their place in the article.
+          </Text>
+          <Text style={styles.paragraph}>
+            The embedded paywall can fire the custom action named {SHOW_ALL_PLANS_ACTION}. This
+            example responds by retrieving {ALL_PLANS_PLACEMENT} and presenting it full-screen with
+            the same getPaywall flow.
+          </Text>
+          {gateDecision !== "unlocked" && (
+            <BlurView
+              experimentalBlurMethod={Platform.OS === "android" ? "dimezisBlurView" : undefined}
+              intensity={28}
+              tint="light"
+              pointerEvents="none"
+              style={styles.blur}
+            />
+          )}
+        </View>
+
+        <Text style={styles.debugStatus}>Full-screen state: {fullScreenStatus}</Text>
+        {fullScreenError && <Text style={styles.errorText}>{fullScreenError}</Text>}
+        <Pressable
+          accessibilityRole="button"
+          onPress={previewFullScreen}
+          style={styles.previewButton}
+        >
+          <Text style={styles.previewButtonLabel}>Preview full-screen presentation</Text>
+        </Pressable>
+        <View style={styles.bottomSpacer} />
+      </ScrollView>
+
+      {mode === "overlay" && gateDecision === "gated" && paywall}
+
+      {fullScreenPlacement && (
+        <Modal
+          animationType="slide"
+          onRequestClose={() => setFullScreenPlacement(null)}
+          presentationStyle="fullScreen"
+          statusBarTranslucent
+          visible
+        >
+          <View style={styles.fullScreenPaywall}>
+            <PaywallView
+              key={fullScreenPlacement}
+              placement={fullScreenPlacement}
+              style={StyleSheet.absoluteFill}
+              renderFallback={(state) =>
+                state.status === "loading" ? (
+                  <View pointerEvents="none" style={styles.fullScreenPlaceholder}>
+                    <ActivityIndicator color="#6d5dfc" size="large" />
+                  </View>
+                ) : null
+              }
+              onPresent={(info) => setFullScreenStatus(`presented ${info.name}`)}
+              onDismiss={(_, result, shouldDismiss) => {
+                setFullScreenStatus(`dismissed: ${result.type}`)
+                if (result.type === "purchased" || result.type === "restored") {
+                  void refreshGateDecision()
+                }
+                if (shouldDismiss) setFullScreenPlacement(null)
+              }}
+              onSkip={(reason) => {
+                setFullScreenStatus(`skipped: ${reason.type}`)
+                setFullScreenPlacement(null)
+              }}
+              onError={(error) => {
+                setFullScreenError(error)
+                setFullScreenStatus("error")
+                setFullScreenPlacement(null)
+              }}
+            />
+          </View>
+        </Modal>
+      )}
+    </View>
+  )
+}
+
+export default function ArticlePaywallPage() {
+  return (
+    <SuperwallProvider
+      apiKeys={{ ios: IOS_API_KEY, android: ANDROID_API_KEY }}
+      options={{ testModeBehavior: __DEV__ ? "always" : "automatic" }}
+    >
+      <SuperwallLoading>
+        <View style={styles.loadingScreen}>
+          <ActivityIndicator size="large" color="#6d5dfc" />
+        </View>
+      </SuperwallLoading>
+      <SuperwallLoaded>
+        <ArticlePaywallDemo />
+      </SuperwallLoaded>
+    </SuperwallProvider>
+  )
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: "#f8f6f1",
+  },
+  loadingScreen: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#f8f6f1",
+  },
+  fullScreenPaywall: {
+    flex: 1,
+    backgroundColor: "#ffffff",
+  },
+  fullScreenPlaceholder: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  article: {
+    paddingHorizontal: 22,
+    paddingTop: 28,
+  },
+  eyebrow: {
+    color: "#6d5dfc",
+    fontSize: 12,
+    fontWeight: "800",
+    letterSpacing: 1.8,
+  },
+  title: {
+    color: "#171625",
+    fontSize: 35,
+    fontWeight: "800",
+    letterSpacing: -1.2,
+    lineHeight: 39,
+    marginTop: 12,
+  },
+  byline: {
+    color: "#77727f",
+    fontSize: 14,
+    marginTop: 12,
+  },
+  modePicker: {
+    alignSelf: "flex-start",
+    backgroundColor: "#e9e5dd",
+    borderRadius: 12,
+    flexDirection: "row",
+    marginVertical: 24,
+    padding: 4,
+  },
+  gateStatus: {
+    color: "#85808a",
+    fontSize: 12,
+    marginBottom: 4,
+    marginTop: -14,
+  },
+  modeButton: {
+    borderRadius: 9,
+    paddingHorizontal: 18,
+    paddingVertical: 9,
+  },
+  modeButtonSelected: {
+    backgroundColor: "#ffffff",
+  },
+  modeLabel: {
+    color: "#716d75",
+    fontSize: 14,
+    fontWeight: "700",
+    textTransform: "capitalize",
+  },
+  modeLabelSelected: {
+    color: "#302b48",
+  },
+  lede: {
+    color: "#292733",
+    fontSize: 20,
+    fontWeight: "600",
+    lineHeight: 30,
+  },
+  paragraph: {
+    color: "#4b4853",
+    fontSize: 17,
+    lineHeight: 28,
+    marginTop: 18,
+  },
+  paywallFrame: {
+    backgroundColor: "#ffffff",
+    borderColor: "#e5e0d7",
+    borderRadius: 20,
+    borderWidth: 1,
+    height: 330,
+    marginHorizontal: -6,
+    marginTop: 28,
+    overflow: "hidden",
+  },
+  overlayFrame: {
+    bottom: 18,
+    height: 300,
+    left: 16,
+    marginHorizontal: 0,
+    marginTop: 0,
+    position: "absolute",
+    right: 16,
+    shadowColor: "#221e35",
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.18,
+    shadowRadius: 20,
+  },
+  paywallPlaceholder: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    gap: 10,
+    justifyContent: "center",
+    padding: 24,
+  },
+  statusText: {
+    color: "#6f6978",
+    fontSize: 13,
+    textAlign: "center",
+  },
+  gatedSection: {
+    marginTop: 28,
+    overflow: "hidden",
+    paddingBottom: 24,
+    position: "relative",
+  },
+  sectionTitle: {
+    color: "#201e2a",
+    fontSize: 26,
+    fontWeight: "800",
+    lineHeight: 32,
+  },
+  blur: {
+    ...StyleSheet.absoluteFillObject,
+    top: 76,
+  },
+  debugStatus: {
+    color: "#85808a",
+    fontSize: 12,
+    marginTop: 16,
+  },
+  errorText: {
+    color: "#b42318",
+    fontSize: 12,
+    lineHeight: 18,
+    marginTop: 6,
+  },
+  previewButton: {
+    alignItems: "center",
+    backgroundColor: "#302b48",
+    borderRadius: 12,
+    marginTop: 12,
+    paddingHorizontal: 18,
+    paddingVertical: 13,
+  },
+  previewButtonLabel: {
+    color: "#ffffff",
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  bottomSpacer: {
+    height: 80,
+  },
+})

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -9,6 +9,7 @@ export default function OuterApp() {
       <Link href="/custom-purchase">Custom Purchase Controller</Link>
       <Link href="/revenuecat">RevenueCat Integration</Link>
       <Link href="/integration-attributes">Integration Attributes</Link>
+      <Link href="/article-paywall">Inline Article Paywall</Link>
     </View>
   )
 }

--- a/ios/SuperwallExpoModule.swift
+++ b/ios/SuperwallExpoModule.swift
@@ -103,6 +103,26 @@ public class SuperwallExpoModule: Module {
       didRedeemLink
     )
 
+    View(SuperwallExpoPaywallView.self) {
+      ViewName("PaywallView")
+      Events(
+        "onPaywallLoadStart",
+        "onPaywallPresent",
+        "onPaywallDismiss",
+        "onPaywallSkip",
+        "onPaywallError"
+      )
+      Prop("placement") { (view: SuperwallExpoPaywallView, placement: String) in
+        view.setPlacement(placement)
+      }
+      Prop("params") { (view: SuperwallExpoPaywallView, params: [String: Any]?) in
+        view.setParams(params)
+      }
+      OnViewDidUpdateProps { (view: SuperwallExpoPaywallView) in
+        view.loadPaywallIfNeeded()
+      }
+    }
+
     AsyncFunction("identify") { (userId: String, options: [String: Any]?, promise: Promise) in
       DispatchQueue.main.async {
         let identityOptions = IdentityOptions.fromJson(options)

--- a/ios/SuperwallExpoPaywallView.swift
+++ b/ios/SuperwallExpoPaywallView.swift
@@ -72,6 +72,8 @@ final class SuperwallExpoPaywallView: ExpoView, PaywallViewControllerDelegate {
           paywall.presentingViewController == nil,
           paywall.viewIfLoaded?.superview == nil
         else {
+          // Allow a later prop update or reattach to retry once the other host lets go.
+          self.configurationKey = nil
           self.onPaywallError([
             "message":
               "The retrieved paywall is already attached to another view. Use a different placement for each mounted PaywallView."
@@ -89,6 +91,9 @@ final class SuperwallExpoPaywallView: ExpoView, PaywallViewControllerDelegate {
         // A new prop set or unmount invalidated this request.
       } catch {
         guard !Task.isCancelled, generation == self.loadGeneration else { return }
+        // A failed load is not a settled decision (unlike a skip): clear the key so
+        // the same configuration can retry on the next prop update or reattach.
+        self.configurationKey = nil
         self.onPaywallError(["message": error.localizedDescription])
       }
     }

--- a/ios/SuperwallExpoPaywallView.swift
+++ b/ios/SuperwallExpoPaywallView.swift
@@ -1,0 +1,181 @@
+import ExpoModulesCore
+import SuperwallKit
+
+/// A React Native host view for a paywall retrieved through Superwall's `getPaywall` API.
+///
+/// Each host owns exactly one PaywallViewController. Changing the placement/params or
+/// removing the host from the hierarchy discards that controller; native paywall
+/// controllers must never be reused in another view hierarchy.
+final class SuperwallExpoPaywallView: ExpoView, PaywallViewControllerDelegate {
+  let onPaywallLoadStart = EventDispatcher()
+  let onPaywallPresent = EventDispatcher()
+  let onPaywallDismiss = EventDispatcher()
+  let onPaywallSkip = EventDispatcher()
+  let onPaywallError = EventDispatcher()
+
+  private var placement: String?
+  private var params: [String: Any]?
+  private var configurationKey: String?
+  private var loadGeneration = 0
+  private var loadTask: Task<Void, Never>?
+  private var paywallViewController: PaywallViewController?
+
+  required init(appContext: AppContext? = nil) {
+    super.init(appContext: appContext)
+    clipsToBounds = true
+  }
+
+  func setPlacement(_ placement: String) {
+    self.placement = placement
+  }
+
+  func setParams(_ params: [String: Any]?) {
+    self.params = params
+  }
+
+  func loadPaywallIfNeeded() {
+    guard window != nil, let placement, !placement.isEmpty else {
+      return
+    }
+
+    let nextConfigurationKey = makeConfigurationKey(placement: placement, params: params)
+    guard nextConfigurationKey != configurationKey else {
+      attachPaywallViewControllerIfNeeded()
+      return
+    }
+
+    configurationKey = nextConfigurationKey
+    loadGeneration += 1
+    let generation = loadGeneration
+    loadTask?.cancel()
+    detachPaywallViewController()
+    onPaywallLoadStart([:])
+
+    loadTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+
+      do {
+        let paywall = try await Superwall.shared.getPaywall(
+          forPlacement: placement,
+          params: self.params,
+          delegate: self
+        )
+
+        guard !Task.isCancelled,
+          generation == self.loadGeneration,
+          self.window != nil
+        else {
+          return
+        }
+
+        guard paywall.parent == nil,
+          paywall.presentingViewController == nil,
+          paywall.viewIfLoaded?.superview == nil
+        else {
+          self.onPaywallError([
+            "message":
+              "The retrieved paywall is already attached to another view. Use a different placement for each mounted PaywallView."
+          ])
+          return
+        }
+
+        self.paywallViewController = paywall
+        self.attachPaywallViewControllerIfNeeded()
+        self.onPaywallPresent(["paywallInfo": paywall.info.toJson()])
+      } catch let reason as PaywallSkippedReason {
+        guard !Task.isCancelled, generation == self.loadGeneration else { return }
+        self.onPaywallSkip(["reason": reason.toJson()])
+      } catch is CancellationError {
+        // A new prop set or unmount invalidated this request.
+      } catch {
+        guard !Task.isCancelled, generation == self.loadGeneration else { return }
+        self.onPaywallError(["message": error.localizedDescription])
+      }
+    }
+  }
+
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+
+    if window == nil {
+      invalidateAndDetach()
+    } else {
+      loadPaywallIfNeeded()
+    }
+  }
+
+  func paywall(
+    _ paywall: PaywallViewController,
+    didFinishWith result: PaywallResult,
+    shouldDismiss: Bool
+  ) {
+    onPaywallDismiss([
+      "paywallInfo": paywall.info.toJson(),
+      "result": result.toJson(),
+      "shouldDismiss": shouldDismiss,
+    ])
+
+    if shouldDismiss {
+      detachPaywallViewController()
+    }
+  }
+
+  func paywall(
+    _ paywall: PaywallViewController,
+    loadingStateDidChange loadingState: PaywallLoadingState
+  ) {}
+
+  private func makeConfigurationKey(placement: String, params: [String: Any]?) -> String {
+    guard let params,
+      JSONSerialization.isValidJSONObject(params),
+      let data = try? JSONSerialization.data(withJSONObject: params, options: [.sortedKeys]),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return placement
+    }
+    return "\(placement):\(json)"
+  }
+
+  private func attachPaywallViewControllerIfNeeded() {
+    guard let paywallViewController,
+      paywallViewController.view.superview !== self,
+      let parentViewController = reactViewController()
+    else {
+      return
+    }
+
+    parentViewController.addChild(paywallViewController)
+
+    let paywallView = paywallViewController.view!
+    paywallView.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(paywallView)
+    NSLayoutConstraint.activate([
+      paywallView.topAnchor.constraint(equalTo: topAnchor),
+      paywallView.bottomAnchor.constraint(equalTo: bottomAnchor),
+      paywallView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      paywallView.trailingAnchor.constraint(equalTo: trailingAnchor),
+    ])
+    paywallViewController.didMove(toParent: parentViewController)
+  }
+
+  private func detachPaywallViewController() {
+    if let paywallViewController {
+      paywallViewController.willMove(toParent: nil)
+      paywallViewController.view.removeFromSuperview()
+      paywallViewController.removeFromParent()
+    }
+    self.paywallViewController = nil
+  }
+
+  private func invalidateAndDetach() {
+    loadGeneration += 1
+    loadTask?.cancel()
+    loadTask = nil
+    configurationKey = nil
+    detachPaywallViewController()
+  }
+
+  deinit {
+    loadTask?.cancel()
+  }
+}

--- a/src/__tests__/paywall-view.test.tsx
+++ b/src/__tests__/paywall-view.test.tsx
@@ -1,0 +1,130 @@
+import { View } from "react-native"
+import TestRenderer, { act } from "react-test-renderer"
+import type { PaywallInfo, PaywallResult, PaywallSkippedReason } from "../SuperwallExpoModule.types"
+
+jest.mock("expo", () => ({
+  requireNativeView: () => "NativePaywallView",
+}))
+
+jest.mock("react-native", () => ({
+  StyleSheet: {
+    absoluteFill: { bottom: 0, left: 0, position: "absolute", right: 0, top: 0 },
+  },
+  View: "View",
+}))
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const {
+  PaywallView,
+}: typeof import("../components/PaywallView") = require("../components/PaywallView")
+
+const paywallInfo = {
+  identifier: "paywall-id",
+  name: "Article Paywall",
+} as PaywallInfo
+const declined = { type: "declined" } satisfies PaywallResult
+const skipped = { type: "PlacementNotFound" } satisfies PaywallSkippedReason
+
+function fallbackFor(state: { status: string }) {
+  return <View testID={`fallback-${state.status}`} />
+}
+
+describe("PaywallView", () => {
+  it("declaratively renders each fallback state and preserves lifecycle callbacks", () => {
+    const onPresent = jest.fn()
+    const onDismiss = jest.fn()
+    const onSkip = jest.fn()
+    const onError = jest.fn()
+
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(
+        <PaywallView
+          placement="article"
+          renderFallback={fallbackFor}
+          onPresent={onPresent}
+          onDismiss={onDismiss}
+          onSkip={onSkip}
+          onError={onError}
+        />,
+      )
+    })
+
+    expect(renderer!.root.findByProps({ testID: "fallback-loading" })).toBeDefined()
+    let nativeView = renderer!.root.findByType("NativePaywallView" as never)
+
+    act(() => {
+      nativeView.props.onPaywallPresent({ nativeEvent: { paywallInfo } })
+    })
+    expect(onPresent).toHaveBeenCalledWith(paywallInfo)
+    expect(renderer!.root.findAllByProps({ testID: "fallback-loading" })).toHaveLength(0)
+
+    nativeView = renderer!.root.findByType("NativePaywallView" as never)
+    act(() => {
+      nativeView.props.onPaywallDismiss({
+        nativeEvent: { paywallInfo, result: declined, shouldDismiss: false },
+      })
+    })
+    expect(onDismiss).toHaveBeenLastCalledWith(paywallInfo, declined, false)
+    expect(renderer!.root.findByType("NativePaywallView" as never)).toBeDefined()
+
+    act(() => {
+      nativeView.props.onPaywallDismiss({
+        nativeEvent: { paywallInfo, result: declined, shouldDismiss: true },
+      })
+    })
+    expect(renderer!.root.findByProps({ testID: "fallback-dismissed" })).toBeDefined()
+    expect(renderer!.root.findAllByType("NativePaywallView" as never)).toHaveLength(0)
+
+    act(() => {
+      renderer!.update(
+        <PaywallView
+          placement="another-article"
+          renderFallback={fallbackFor}
+          onSkip={onSkip}
+          onError={onError}
+        />,
+      )
+    })
+    expect(renderer!.root.findByProps({ testID: "fallback-loading" })).toBeDefined()
+    nativeView = renderer!.root.findByType("NativePaywallView" as never)
+
+    act(() => {
+      nativeView.props.onPaywallSkip({ nativeEvent: { reason: skipped } })
+    })
+    expect(onSkip).toHaveBeenCalledWith(skipped)
+    expect(renderer!.root.findByProps({ testID: "fallback-skipped" })).toBeDefined()
+
+    act(() => {
+      renderer!.update(
+        <PaywallView
+          placement="error-article"
+          renderFallback={fallbackFor}
+          onSkip={onSkip}
+          onError={onError}
+        />,
+      )
+    })
+    nativeView = renderer!.root.findByType("NativePaywallView" as never)
+    act(() => {
+      nativeView.props.onPaywallError({ nativeEvent: { message: "Network unavailable" } })
+    })
+    expect(onError).toHaveBeenCalledWith("Network unavailable")
+    expect(renderer!.root.findByProps({ testID: "fallback-error" })).toBeDefined()
+  })
+
+  it("collapses terminal states when no fallback is provided", () => {
+    let renderer: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(<PaywallView placement="article" />)
+    })
+
+    const nativeView = renderer!.root.findByType("NativePaywallView" as never)
+    act(() => {
+      nativeView.props.onPaywallSkip({ nativeEvent: { reason: skipped } })
+    })
+
+    expect(renderer!.toJSON()).toBeNull()
+  })
+})

--- a/src/components/PaywallView.tsx
+++ b/src/components/PaywallView.tsx
@@ -1,0 +1,130 @@
+import { requireNativeView } from "expo"
+import { type ReactNode, useEffect, useRef, useState } from "react"
+import { type NativeSyntheticEvent, StyleSheet, View, type ViewProps } from "react-native"
+import type { PaywallInfo, PaywallResult, PaywallSkippedReason } from "../SuperwallExpoModule.types"
+
+type LoadStartEvent = NativeSyntheticEvent<Record<string, never>>
+type PresentEvent = NativeSyntheticEvent<{ paywallInfo: PaywallInfo }>
+type DismissEvent = NativeSyntheticEvent<{
+  paywallInfo: PaywallInfo
+  result: PaywallResult
+  shouldDismiss: boolean
+}>
+type SkipEvent = NativeSyntheticEvent<{ reason: PaywallSkippedReason }>
+type ErrorEvent = NativeSyntheticEvent<{ message: string }>
+
+type NativePaywallViewProps = {
+  placement: string
+  params?: Record<string, any>
+  style?: ViewProps["style"]
+  onPaywallLoadStart?: (event: LoadStartEvent) => void
+  onPaywallPresent?: (event: PresentEvent) => void
+  onPaywallDismiss?: (event: DismissEvent) => void
+  onPaywallSkip?: (event: SkipEvent) => void
+  onPaywallError?: (event: ErrorEvent) => void
+}
+
+const NativePaywallView = requireNativeView<NativePaywallViewProps>("SuperwallExpo", "PaywallView")
+
+export type PaywallFallbackState =
+  | { status: "loading" }
+  | { status: "skipped"; reason: PaywallSkippedReason }
+  | { status: "error"; error: string }
+  | { status: "dismissed"; paywallInfo: PaywallInfo; result: PaywallResult }
+
+type PaywallViewState = PaywallFallbackState | { status: "presented"; paywallInfo: PaywallInfo }
+
+export interface PaywallViewProps extends Omit<ViewProps, "children"> {
+  /** The placement whose paywall should be retrieved. */
+  placement: string
+  /** Optional parameters used to evaluate and render the placement. */
+  params?: Record<string, any>
+  /**
+   * Renders UI while the paywall is loading or after it is skipped, fails, or dismisses.
+   * Returning `null` for a terminal state removes the PaywallView from the layout.
+   */
+  renderFallback?: (state: PaywallFallbackState) => ReactNode
+  /** Called once the paywall has been retrieved and attached to the inline host. */
+  onPresent?: (paywallInfo: PaywallInfo) => void
+  /** Called when the embedded paywall finishes an interaction. */
+  onDismiss?: (paywallInfo: PaywallInfo, result: PaywallResult, shouldDismiss: boolean) => void
+  /** Called when campaign rules intentionally skip the requested paywall. */
+  onSkip?: (reason: PaywallSkippedReason) => void
+  /** Called when the paywall cannot be retrieved or attached. */
+  onError?: (error: string) => void
+}
+
+/**
+ * Embeds a Superwall paywall inside a React Native layout.
+ *
+ * Give the view an explicit width/height, and unmount it when the surrounding
+ * content no longer needs it. Each mounted component owns its native paywall;
+ * use different placements for paywalls mounted at the same time.
+ */
+export function PaywallView({
+  placement,
+  params,
+  renderFallback,
+  onPresent,
+  onDismiss,
+  onSkip,
+  onError,
+  style,
+  ...viewProps
+}: PaywallViewProps) {
+  const [state, setState] = useState<PaywallViewState>({ status: "loading" })
+  const configurationKey = `${placement}:${JSON.stringify(params ?? null)}`
+  const previousConfigurationKey = useRef(configurationKey)
+
+  useEffect(() => {
+    if (previousConfigurationKey.current !== configurationKey) {
+      previousConfigurationKey.current = configurationKey
+      setState({ status: "loading" })
+    }
+  }, [configurationKey])
+
+  const fallback = state.status === "presented" ? null : renderFallback?.(state)
+  const isTerminal =
+    state.status === "skipped" || state.status === "error" || state.status === "dismissed"
+
+  if (isTerminal) {
+    if (fallback === null || fallback === undefined || fallback === false) return null
+    return (
+      <View {...viewProps} style={style}>
+        {fallback}
+      </View>
+    )
+  }
+
+  return (
+    <View {...viewProps} style={style}>
+      <NativePaywallView
+        placement={placement}
+        params={params}
+        style={StyleSheet.absoluteFill}
+        onPaywallLoadStart={() => setState({ status: "loading" })}
+        onPaywallPresent={(event) => {
+          const { paywallInfo } = event.nativeEvent
+          setState({ status: "presented", paywallInfo })
+          onPresent?.(paywallInfo)
+        }}
+        onPaywallDismiss={(event) => {
+          const { paywallInfo, result, shouldDismiss } = event.nativeEvent
+          if (shouldDismiss) setState({ status: "dismissed", paywallInfo, result })
+          onDismiss?.(paywallInfo, result, shouldDismiss)
+        }}
+        onPaywallSkip={(event) => {
+          const { reason } = event.nativeEvent
+          setState({ status: "skipped", reason })
+          onSkip?.(reason)
+        }}
+        onPaywallError={(event) => {
+          const { message } = event.nativeEvent
+          setState({ status: "error", error: message })
+          onError?.(message)
+        }}
+      />
+      {fallback}
+    </View>
+  )
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
+export * from "./PaywallView"
 export * from "./SuperwallLoading"


### PR DESCRIPTION
## Summary

- add a typed React `PaywallView` backed by native `getPaywall` views on iOS and Android
- expose declarative loading, skipped, error, and dismissed UI through `renderFallback`
- own and clean up each native paywall instance across prop changes and unmounts
- add an article example covering remote `getPresentationResult` gating, inline and overlay layouts, and full-screen presentation through a React Native `Modal`
- add lifecycle and fallback-state regression coverage plus a minor changeset

## Testing

- `yarn biome check src/components/PaywallView.tsx src/__tests__/paywall-view.test.tsx example/app/article-paywall.tsx`
- `yarn build`
- `tsc -p example/tsconfig.json --noEmit`
- `npx jest@29.7.0 --runInBand src/__tests__/paywall-view.test.tsx`
- Android `:expo-superwall:compileDebugKotlin :app:assembleDebug`
- iOS `SuperwallExpo` simulator build with `xcodebuild`

## Linear

[SW-5639: Expo: Investigate supporting getPaywall & PaywallView to power inline paywalls](https://linear.app/superwall/issue/SW-5639/expo-investigate-supporting-getpaywall-andamp-paywallview-to-power)